### PR TITLE
feat: 支持ip段

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ default: fmt lint vet
 
 .PHONY: local
 local: ## 构建二进制
-	docker run --rm -v ${PWD}:/go/src/github.com/fanux/sealos -w /go/src/github.com/fanux/sealos golang:1.12-stretch  go build -ldflags "-X 'github.com/fanux/sealos/version.Version=${BUILD_VERSION}'"
+	docker run --rm -v ${PWD}:/go/src/github.com/fanux/sealos -w /go/src/github.com/fanux/sealos golang:1.12-stretch  go build -ldflags "-X 'github.com/fanux/sealos/version.Version=${BUILD_VERSION}' -X 'github.com/fanux/sealos/version.Build=${COMMIT_SHA1}'"
 
 help: ## this help
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {sub("\\\\n",sprintf("\n%22c"," "), $$2);printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)

--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,3 @@
 # build.sh v3.0.2
-go build -o sealos -ldflags "-X github.com/fanux/sealos/version.Version=$1" main.go
+COMMIT_SHA1=$(git rev-parse --short HEAD || echo "0.0.0")
+go build -o sealos -ldflags "-X github.com/fanux/sealos/version.Version=$1 -X github.com/fanux/sealos/version.Build=${COMMIT_SHA1}" main.go

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -48,4 +48,6 @@ func init() {
 	cleanCmd.Flags().StringVar(&install.ApiServer, "apiserver", "apiserver.cluster.local", "apiserver domain name")
 	cleanCmd.Flags().StringSliceVar(&install.Masters, "master", []string{}, "kubernetes masters")
 	cleanCmd.Flags().StringSliceVar(&install.Nodes, "node", []string{}, "kubernetes nodes")
+	cleanCmd.Flags().StringSliceVar(&install.MasterIPs, "masters", []string{}, "kubernetes multi-masters")
+	cleanCmd.Flags().StringSliceVar(&install.NodeIPs, "nodes", []string{}, "kubernetes multi-nodes")
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -45,7 +45,8 @@ func init() {
 	initCmd.Flags().StringVar(&install.VIP, "vip", "10.103.97.2", "virtual ip")
 	initCmd.Flags().StringSliceVar(&install.Masters, "master", []string{}, "kubernetes masters")
 	initCmd.Flags().StringSliceVar(&install.Nodes, "node", []string{}, "kubernetes nodes")
-
+	initCmd.Flags().StringSliceVar(&install.MasterIPs, "masters", []string{}, "kubernetes multi-masters ex. 192.168.0.2-192.168.0.4")
+	initCmd.Flags().StringSliceVar(&install.NodeIPs, "nodes", []string{}, "kubernetes multi-nodes ex. 192.168.0.5-192.168.0.5")
 	initCmd.Flags().StringVar(&install.PkgUrl, "pkg-url", "", "http://store.lameleg.com/kube1.14.1.tar.gz download offline package url, or file localtion ex. /root/kube1.14.1.tar.gz")
 	initCmd.Flags().StringVar(&install.Version, "version", "v1.14.1", "version is kubernetes version")
 	initCmd.Flags().StringVar(&install.Repo, "repo", "k8s.gcr.io", "choose a container registry to pull control plane images from")

--- a/cmd/join.go
+++ b/cmd/join.go
@@ -40,6 +40,8 @@ func init() {
 	joinCmd.Flags().StringVar(&install.VIP, "vip", "10.103.97.2", "virtual ip")
 	joinCmd.Flags().StringSliceVar(&install.Masters, "master", []string{}, "kubernetes masters")
 	joinCmd.Flags().StringSliceVar(&install.Nodes, "node", []string{}, "kubernetes nodes")
+	joinCmd.Flags().StringSliceVar(&install.MasterIPs, "masters", []string{}, "kubernetes multi-masters ex. 192.168.0.2-192.168.0.4")
+	joinCmd.Flags().StringSliceVar(&install.NodeIPs, "nodes", []string{}, "kubernetes multi-nodes ex. 192.168.0.5-192.168.0.5")
 
 	joinCmd.Flags().StringVar(&install.PkgUrl, "pkg-url", "", "http://store.lameleg.com/kube1.14.1.tar.gz download offline pakage url, or file localtion ex. /root/kube1.14.1.tar.gz")
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -17,7 +17,6 @@ package cmd
 import (
 	"fmt"
 	"github.com/fanux/sealos/version"
-
 	"github.com/spf13/cobra"
 )
 
@@ -27,7 +26,7 @@ var versionCmd = &cobra.Command{
 	Short: "show sealos version",
 	Long:  `show sealos version`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println(version.Version)
+		fmt.Println(version.VersionStr)
 	},
 }
 

--- a/install/check.go
+++ b/install/check.go
@@ -8,8 +8,14 @@ import (
 
 //CheckValid is
 func (s *SealosInstaller) CheckValid() {
-	hosts := append(Masters, Nodes...)
-	if len(Masters) == 0{
+	//hosts := append(Masters, Nodes...)
+	// 所有master节点
+	//masters := append(Masters, ParseIPs(MasterIPs)...)
+	// 所有node节点
+	//nodes := append(Nodes, ParseIPs(NodeIPs)...)
+	//hosts := append(masters, nodes...)
+
+	if len(s.Masters) == 0{
 		s.Print("Fail")
 		logger.Error("master not allow empty")
 		os.Exit(1)
@@ -21,7 +27,7 @@ func (s *SealosInstaller) CheckValid() {
 	}
 	var session *ssh.Session
 	var errors []error
-	for _, h := range hosts {
+	for _, h := range s.Hosts {
 		session, err := Connect(User, Passwd, PrivateKeyFile, h)
 		if err != nil {
 			logger.Error("[%s] ------------ check error", h)

--- a/install/clean.go
+++ b/install/clean.go
@@ -7,9 +7,16 @@ import (
 
 //BuildClean is
 func BuildClean() {
-	hosts := append(Masters, Nodes...)
+	//hosts := append(Masters, Nodes...)
+	// 所有master节点
+	masters := append(Masters, ParseIPs(MasterIPs)...)
+	// 所有node节点
+	nodes := append(Nodes, ParseIPs(NodeIPs)...)
+	hosts := append(masters, nodes...)
 	i := &SealosInstaller{
 		Hosts: hosts,
+		Masters: masters,
+		Nodes: nodes,
 	}
 	i.CheckValid()
 	i.Clean()

--- a/install/config.go
+++ b/install/config.go
@@ -32,8 +32,8 @@ func (c *SealConfig) Dump(path string) {
 		path = defaultConfigPath + defaultConfigFile
 	}
 
-	c.Masters = Masters
-	c.Nodes = Nodes
+	c.Masters = append(Masters, ParseIPs(MasterIPs)...)
+	c.Nodes = append(Nodes, ParseIPs(NodeIPs)...)
 	c.User = User
 	c.Passwd = Passwd
 	c.PrivateKey = PrivateKeyFile

--- a/install/generator.go
+++ b/install/generator.go
@@ -69,7 +69,8 @@ func TemplateFromTemplateContent(templateContent string) []byte {
 		panic(1)
 	}
 	var masters []string
-	for _, h := range Masters {
+	getmasters := append(Masters, ParseIPs(MasterIPs)...)
+	for _, h := range getmasters {
 		masters = append(masters, IpFormat(h))
 	}
 	var envMap = make(map[string]interface{})

--- a/install/join.go
+++ b/install/join.go
@@ -7,8 +7,14 @@ import (
 
 //BuildJoin is
 func BuildJoin() {
+	// 所有master节点
+	masters := append(Masters, ParseIPs(MasterIPs)...)
+	// 所有node节点
+	nodes := append(Nodes, ParseIPs(NodeIPs)...)
 	i := &SealosInstaller{
-		Hosts: Nodes,
+		Hosts: nodes,
+		Masters: masters,
+		Nodes: nodes,
 	}
 	i.CheckValid()
 	i.SendPackage("kube")
@@ -19,18 +25,18 @@ func BuildJoin() {
 //GeneratorToken is
 func (s *SealosInstaller) GeneratorToken() {
 	cmd := `kubeadm token create --print-join-command`
-	output := Cmd(Masters[0], cmd)
+	output := Cmd(s.Masters[0], cmd)
 	decodeOutput(output)
 }
 
 //JoinMasters is
 func (s *SealosInstaller) JoinMasters() {
 	cmd := s.Command(Version, JoinMaster)
-	for _, master := range Masters[1:] {
-		cmdHosts := fmt.Sprintf("echo %s %s >> /etc/hosts", IpFormat(Masters[0]), ApiServer)
+	for _, master := range s.Masters[1:] {
+		cmdHosts := fmt.Sprintf("echo %s %s >> /etc/hosts", IpFormat(s.Masters[0]), ApiServer)
 		Cmd(master, cmdHosts)
 		Cmd(master, cmd)
-		cmdHosts = fmt.Sprintf(`sed "s/%s/%s/g" -i /etc/hosts`, IpFormat(Masters[0]), IpFormat(master))
+		cmdHosts = fmt.Sprintf(`sed "s/%s/%s/g" -i /etc/hosts`, IpFormat(s.Masters[0]), IpFormat(master))
 		Cmd(master, cmdHosts)
 		copyk8sConf := `mkdir -p /root/.kube && cp -i /etc/kubernetes/admin.conf /root/.kube/config`
 		Cmd(master, copyk8sConf)
@@ -41,11 +47,11 @@ func (s *SealosInstaller) JoinMasters() {
 func (s *SealosInstaller) JoinNodes() {
 	var masters string
 	var wg sync.WaitGroup
-	for _, master := range Masters {
+	for _, master := range s.Masters {
 		masters += fmt.Sprintf(" --master %s:6443", IpFormat(master))
 	}
 
-	for _, node := range Nodes {
+	for _, node := range s.Nodes {
 		wg.Add(1)
 		go func(node string) {
 			defer wg.Done()

--- a/install/sealos.go
+++ b/install/sealos.go
@@ -41,6 +41,8 @@ var (
 //SealosInstaller is
 type SealosInstaller struct {
 	Hosts []string
+	Masters []string
+	Nodes []string
 }
 
 type CommandType string
@@ -54,14 +56,14 @@ func (s *SealosInstaller) Command(version string, name CommandType) (cmd string)
 	cmds := make(map[CommandType]string)
 	cmds = map[CommandType]string{
 		InitMaster: `kubeadm init --config=/root/kubeadm-config.yaml --experimental-upload-certs`,
-		JoinMaster: fmt.Sprintf("kubeadm join %s:6443 --token %s --discovery-token-ca-cert-hash %s --experimental-control-plane --certificate-key %s", IpFormat(Masters[0]), JoinToken, TokenCaCertHash, CertificateKey),
+		JoinMaster: fmt.Sprintf("kubeadm join %s:6443 --token %s --discovery-token-ca-cert-hash %s --experimental-control-plane --certificate-key %s", IpFormat(s.Masters[0]), JoinToken, TokenCaCertHash, CertificateKey),
 		JoinNode:   fmt.Sprintf("kubeadm join %s:6443 --token %s --discovery-token-ca-cert-hash %s", VIP, JoinToken, TokenCaCertHash),
 	}
 	//other version
 	//todo
 	if VersionToInt(version) >= 115 {
 		cmds[InitMaster] = `kubeadm init --config=/root/kubeadm-config.yaml --upload-certs`
-		cmds[JoinMaster] = fmt.Sprintf("kubeadm join %s:6443 --token %s --discovery-token-ca-cert-hash %s --control-plane --certificate-key %s", IpFormat(Masters[0]), JoinToken, TokenCaCertHash, CertificateKey)
+		cmds[JoinMaster] = fmt.Sprintf("kubeadm join %s:6443 --token %s --discovery-token-ca-cert-hash %s --control-plane --certificate-key %s", IpFormat(s.Masters[0]), JoinToken, TokenCaCertHash, CertificateKey)
 	}
 
 	v, ok := cmds[name]

--- a/install/vars.go
+++ b/install/vars.go
@@ -3,6 +3,8 @@ package install
 var (
 	Masters        []string
 	Nodes          []string
+	MasterIPs     []string
+	NodeIPs       []string
 	VIP            string
 	PkgUrl         string
 	User           string

--- a/version/version.go
+++ b/version/version.go
@@ -1,3 +1,12 @@
 package version
 
-var Version = "latest"
+import (
+	"fmt"
+	"runtime"
+)
+
+var (
+	Version = "latest"
+	Build = ""
+	VersionStr =  fmt.Sprintf("sealos version %v, build %v %v", Version, Build, runtime.Version())
+)


### PR DESCRIPTION
fix #183

init/join 命令新增了masters/nodes参数，格式为`ip-ip`

```
sealos init --passwd vagrant --podcidr 172.16.0.0/16 --repo registry.cn-hangzhou.aliyuncs.com/google_containers --version 1.17.0 --pkg-url /root/kube1.17.0.tar.gz \
	--masters 192.168.100.101-192.168.100.101 \
	--nodes 192.168.100.102-192.168.100.102 \
        --node 192.168.100.103
```