### PR TITLE
kubeadm 集群配置优化

### DIFF
--- a/install/generator.go
+++ b/install/generator.go
@@ -14,16 +14,33 @@ kubernetesVersion: {{.Version}}
 controlPlaneEndpoint: "{{.ApiServer}}:6443"
 imageRepository: {{.Repo}}
 networking:
+  # dnsDomain: cluster.local
   podSubnet: {{.PodCIDR}}
   serviceSubnet: {{.SvcCIDR}}
 apiServer:
+	extraArgs:
+		feature-gates: TTLAfterFinished=true
         certSANs:
         - 127.0.0.1
         - {{.ApiServer}}
         {{range .Masters -}}
         - {{.}}
         {{end -}}
-        - {{.VIP}}
+	- {{.VIP}}
+	extraVolumes:
+	- hostPath: /etc/localtime
+	mountPath: /etc/localtime
+	name: localtime
+controllerManager:
+	extraVolumes:
+	- hostPath: /etc/localtime
+	mountPath: /etc/localtime
+	name: localtime
+scheduler:
+	extraVolumes:
+	- hostPath: /etc/localtime
+	mountPath: /etc/localtime
+	name: localtime
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration

--- a/install/generator.go
+++ b/install/generator.go
@@ -18,36 +18,46 @@ networking:
   podSubnet: {{.PodCIDR}}
   serviceSubnet: {{.SvcCIDR}}
 apiServer:
-	extraArgs:
-		feature-gates: TTLAfterFinished=true
-        certSANs:
-        - 127.0.0.1
-        - {{.ApiServer}}
-        {{range .Masters -}}
-        - {{.}}
-        {{end -}}
-	- {{.VIP}}
-	extraVolumes:
-	- hostPath: /etc/localtime
-	mountPath: /etc/localtime
-	name: localtime
+  certSANs:
+  - 127.0.0.1
+  - {{.ApiServer}}
+  {{range .Masters -}}
+  - {{.}}
+  {{end -}}
+  - {{.VIP}}
+  extraArgs:
+    feature-gates: TTLAfterFinished=true
+  extraVolumes:
+  - name: localtime
+    hostPath: /etc/localtime
+    mountPath: /etc/localtime
+    readOnly: true
+    pathType: File
 controllerManager:
-	extraVolumes:
-	- hostPath: /etc/localtime
-	mountPath: /etc/localtime
-	name: localtime
+  extraArgs:
+    feature-gates: TTLAfterFinished=true
+  extraVolumes:
+  - hostPath: /etc/localtime
+    mountPath: /etc/localtime
+    name: localtime
+    readOnly: true
+    pathType: File
 scheduler:
-	extraVolumes:
-	- hostPath: /etc/localtime
-	mountPath: /etc/localtime
-	name: localtime
+  extraArgs:
+    feature-gates: TTLAfterFinished=true
+  extraVolumes:
+  - hostPath: /etc/localtime
+    mountPath: /etc/localtime
+    name: localtime
+    readOnly: true
+    pathType: File
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 mode: "ipvs"
 ipvs:
-        excludeCIDRs: 
-        - "{{.VIP}}/32"`)
+  excludeCIDRs: 
+  - "{{.VIP}}/32"`)
 
 var ConfigType string
 


### PR DESCRIPTION
- k8s 服务启动挂载`/etc/localtime`
- 新增了自动清理Job特性`TTLAfterFinished `

原因：
利用Job跑CI，大量pod/job完成后成功于否都未被清理

## 参考

https://godoc.org/k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta1