### PR TITLE
add build timestamp to sealos version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ default: fmt lint vet
 
 .PHONY: local
 local: ## 构建二进制
-	docker run --rm -v ${PWD}:/go/src/github.com/fanux/sealos -w /go/src/github.com/fanux/sealos golang:1.12-stretch  go build -ldflags "-X 'github.com/fanux/sealos/version.Version=${BUILD_VERSION}' -X 'github.com/fanux/sealos/version.Build=${COMMIT_SHA1}'"
+	docker run --rm -v ${PWD}:/go/src/github.com/fanux/sealos -w /go/src/github.com/fanux/sealos golang:1.12-stretch  go build -ldflags "-X 'github.com/fanux/sealos/version.Version=${BUILD_VERSION}' -X 'github.com/fanux/sealos/version.Build=${COMMIT_SHA1}' -X 'github.com/fanux/sealos/version.Buildstamp=${BUILD_TIME}'"
 
 help: ## this help
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {sub("\\\\n",sprintf("\n%22c"," "), $$2);printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)

--- a/build-in-docker-and-put-oss.sh
+++ b/build-in-docker-and-put-oss.sh
@@ -1,5 +1,6 @@
 # build.sh v3.0.2
 COMMIT_SHA1=$(git rev-parse --short HEAD || echo "0.0.0")
+BUILD_TIME=$(date "+%F %T")
 docker run -v $GOPATH/src/github.com/fanux/sealos:/go/src/github.com/fanux/sealos -w /go/src/github.com/fanux/sealos --rm golang:1.13.5 \
-  go build -o sealos -mod vendor -ldflags "-X github.com/fanux/sealos/version.Version=$1 -X github.com/fanux/sealos/version.Build=${COMMIT_SHA1}" main.go
+  go build -o sealos -mod vendor -ldflags "-X github.com/fanux/sealos/version.Version=$1 -X github.com/fanux/sealos/version.Build=${COMMIT_SHA1} -X 'github.com/fanux/sealos/version.Buildstamp=${BUILD_TIME}'" main.go
 ../ossutil64 -c ../oss-config cp -f sealos oss://sealyun/$1/sealos

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,4 @@
 # build.sh v3.0.2
 COMMIT_SHA1=$(git rev-parse --short HEAD || echo "0.0.0")
-go build -o sealos -mod vendor -ldflags "-X github.com/fanux/sealos/version.Version=$1 -X github.com/fanux/sealos/version.Build=${COMMIT_SHA1}" main.go
+BUILD_TIME=$(date "+%F %T")
+go build -o sealos -mod vendor -ldflags "-X github.com/fanux/sealos/version.Version=$1 -X github.com/fanux/sealos/version.Build=${COMMIT_SHA1} -X 'github.com/fanux/sealos/version.Buildstamp=${BUILD_TIME}'" main.go

--- a/version/version.go
+++ b/version/version.go
@@ -8,5 +8,7 @@ import (
 var (
 	Version    = "latest"
 	Build      = ""
-	VersionStr = fmt.Sprintf("sealos version %v, build %v %v", Version, Build, runtime.Version())
+	BuildTime = ""
+	// VersionStr = fmt.Sprintf("sealos version %v, build %v %v", Version, Build, runtime.Version())
+	VersionStr = fmt.Sprintf("sealos version %v, build %v %v, Build Time : %v", Version, Build, runtime.Version(), BuildTime)
 )


### PR DESCRIPTION
[SKIP CI]seaols: 一句话简短描述该PR内容

./sealos version
sealos version v3.3.8, build 9c94143 go1.14.3, UTC Build Time : 2020-06-29 08:31:25 UTC