### PR TITLE
#377 add --cert-sans参数, 快速把指定ip或者域名放入apiserver证书使用.

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -80,6 +80,7 @@ func init() {
 	initCmd.Flags().StringVar(&install.VIP, "vip", "10.103.97.2", "virtual ip")
 	initCmd.Flags().StringSliceVar(&install.MasterIPs, "master", []string{}, "kubernetes multi-masters ex. 192.168.0.2-192.168.0.4")
 	initCmd.Flags().StringSliceVar(&install.NodeIPs, "node", []string{}, "kubernetes multi-nodes ex. 192.168.0.5-192.168.0.5")
+	initCmd.Flags().StringSliceVar(&install.CertSANS, "cert-sans", []string{}, "kubernetes apiServerCertSANs ex. 47.0.0.22 sealyun.com ")
 
 	initCmd.Flags().StringVar(&install.PkgUrl, "pkg-url", "", "http://store.lameleg.com/kube1.14.1.tar.gz download offline package url, or file location ex. /root/kube1.14.1.tar.gz")
 	initCmd.Flags().StringVar(&install.Version, "version", "v1.14.1", "version is kubernetes version")

--- a/install/generator.go
+++ b/install/generator.go
@@ -25,6 +25,9 @@ apiServer:
   {{range .Masters -}}
   - {{.}}
   {{end -}}
+  {{range .CertSANS -}}
+  - {{.}}
+  {{end -}}
   - {{.VIP}}
   extraArgs:
     feature-gates: TTLAfterFinished=true
@@ -103,6 +106,7 @@ func TemplateFromTemplateContent(templateContent string) []byte {
 		masters = append(masters, IpFormat(h))
 	}
 	var envMap = make(map[string]interface{})
+	envMap["CertSANS"] = CertSANS
 	envMap["VIP"] = VIP
 	envMap["Masters"] = masters
 	envMap["Version"] = Version

--- a/install/init.go
+++ b/install/init.go
@@ -80,6 +80,10 @@ func (s *SealosInstaller) KubeadmConfigInstall() {
 
 func getDefaultSANs() []string {
 	var sans = []string{"127.0.0.1", "apiserver.cluster.local", VIP}
+	// 指定的certSANS不为空, 则添加进去
+	if len(CertSANS) != 0 {
+		sans = append(sans, CertSANS...)
+	}
 	for _, master := range MasterIPs {
 		sans = append(sans, IpFormat(master))
 	}

--- a/install/vars.go
+++ b/install/vars.go
@@ -11,6 +11,7 @@ import (
 var (
 	MasterIPs []string
 	NodeIPs   []string
+	CertSANS  []string
 	//config from kubeadm.cfg
 	DnsDomain         string
 	ApiServerCertSANs []string


### PR DESCRIPTION
1. 在kubeadm的默认的模板文件,添加certsans信息
2. 如果默认模板解析失效的时候, 用户增加了certs-san, 则需要添加默认的certs-sans
