### PR TITLE
sealos install --pkg-url ，pkg-url文件位置不对，则立即退出安装　

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -17,7 +17,6 @@ package cmd
 import (
 	"github.com/fanux/sealos/install"
 	"github.com/spf13/cobra"
-	"github.com/wonderivan/logger"
 	"os"
 )
 
@@ -32,10 +31,9 @@ var installCmd = &cobra.Command{
 		install.AppInstall(AppURL)
 	},
 	PreRun: func(cmd *cobra.Command, args []string) {
-		if AppURL == "" {
-			logger.Error("your pkg-url is empty,please check your command is ok?")
+		if install.PkgUrlChek(AppURL) {
 			cmd.Help()
-			os.Exit(0)
+			os.Exit(install.ErrorExitOSCase)
 		}
 	},
 }


### PR DESCRIPTION
sealos init 有pkgurl判断．　
sealos install 同理应该是一样的判断．　都可以从远程安装．　所以判断是一样的

这里我没有考虑到install命令的一些插件的大小，　
比如kuboard.tar只有57Ｍ，　所以前面写的`resp.ContentLength < MinDownloadFileSize` 这个判断可能还不合适．　

＠cuisongliu  有什么好方法么．．