### PR TITLE
默认pk先认证。 #395 ssh 验证优化。

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -44,7 +44,7 @@ var contact = `
 var initCmd = &cobra.Command{
 	Use:   "init",
 	Short: "Simplest way to init your kubernets HA cluster",
-	Long:  `sealos init --master 192.168.0.2 --master 192.168.0.3 --master 192.168.0.4 \
+	Long: `sealos init --master 192.168.0.2 --master 192.168.0.3 --master 192.168.0.4 \
 	--node 192.168.0.5 --user root --passwd your-server-password \
 	--version v1.18.0 --pkg-url=/root/kube1.18.0.tar.gz`,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -71,6 +71,7 @@ func init() {
 	initCmd.Flags().StringVar(&install.SSHConfig.User, "user", "root", "servers user name for ssh")
 	initCmd.Flags().StringVar(&install.SSHConfig.Password, "passwd", "", "password for ssh")
 	initCmd.Flags().StringVar(&install.SSHConfig.PkFile, "pk", "/root/.ssh/id_rsa", "private key for ssh")
+	initCmd.Flags().StringVar(&install.SSHConfig.PkPassword, "pk-passwd", "", "private key password for ssh")
 
 	initCmd.Flags().StringVar(&install.KubeadmFile, "kubeadm-config", "", "kubeadm-config.yaml template file")
 

--- a/install/check.go
+++ b/install/check.go
@@ -39,7 +39,7 @@ func (s *SealosInstaller) CheckValid() {
 			logger.Error("[%s] ------------ check error", h)
 			os.Exit(1)
 		} else {
-			SetHosts(h,hostname)
+			SetHosts(h, hostname)
 			if _, ok := dict[hostname]; !ok {
 				dict[hostname] = true //不冲突, 主机名加入字典
 			} else {

--- a/install/config.go
+++ b/install/config.go
@@ -23,6 +23,7 @@ type SealConfig struct {
 	User       string
 	Passwd     string
 	PrivateKey string
+	PkPassword string
 	//ApiServer ex. apiserver.cluster.local
 	ApiServerDomian string
 
@@ -53,6 +54,7 @@ func (c *SealConfig) Dump(path string) {
 	c.User = SSHConfig.User
 	c.Passwd = SSHConfig.Password
 	c.PrivateKey = SSHConfig.PkFile
+	c.PkPassword = SSHConfig.PkPassword
 	c.ApiServerDomian = ApiServer
 	c.VIP = VIP
 	c.PkgURL = PkgUrl

--- a/install/utils_test.go
+++ b/install/utils_test.go
@@ -132,9 +132,9 @@ func TestFileExist(t *testing.T) {
 		args args
 		want bool
 	}{
-		{"file exist",args{"/home/louis/.ssh/id_rsa"},true},
-		{"file not exist",args{"/home/louis/.ssh/id_rsa.public"},false},
-		{"PkgFile",args{"/root/kube1.18.0.tar.gz"},false},
+		{"file exist", args{"/home/louis/.ssh/id_rsa"}, true},
+		{"file not exist", args{"/home/louis/.ssh/id_rsa.public"}, false},
+		{"PkgFile", args{"/root/kube1.18.0.tar.gz"}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/sshcmd/sshutil/connect.go
+++ b/pkg/sshcmd/sshutil/connect.go
@@ -15,7 +15,7 @@ import (
 这里主要是做连接ssh操作的
 */
 func (ss *SSH) connect(host string) (*ssh.Client, error) {
-	auth := []ssh.AuthMethod{ss.sshAuthMethod(ss.Password, ss.PkFile)}
+	auth := ss.sshAuthMethod(ss.Password, ss.PkFile, ss.PkPassword)
 	config := ssh.Config{
 		Ciphers: []string{"aes128-ctr", "aes192-ctr", "aes256-ctr", "aes128-gcm@openssh.com", "arcfour256", "arcfour128", "aes128-cbc", "3des-cbc", "aes192-cbc", "aes256-cbc"},
 	}
@@ -61,29 +61,60 @@ func (ss *SSH) Connect(host string) (*ssh.Session, error) {
 	return session, nil
 }
 
-func (ss *SSH) sshAuthMethod(passwd, pkFile string) ssh.AuthMethod {
-	var am ssh.AuthMethod
-	if passwd != "" {
-		am = ssh.Password(passwd)
-	} else {
-		pkData := ss.readFile(pkFile)
-		pk, err := ssh.ParsePrivateKey([]byte(pkData))
-		if err != nil {
-			logger.Error(err)
-			os.Exit(1)
+func (ss *SSH) sshAuthMethod(passwd, pkFile, pkPasswd string) (auth []ssh.AuthMethod) {
+	// pkfile存在， 就进行密钥验证， 如果不存在，则跳过密钥验证。
+	if fileExist(pkFile) {
+		am, err := ss.sshPrivateKeyMethod(pkFile, pkPasswd)
+		// 获取到密钥验证就添加， 没获取到就直接跳过。
+		if err == nil {
+			auth = append(auth, am)
 		}
-		am = ssh.PublicKeys(pk)
 	}
-	return am
+	// 密码不为空， 则添加密码验证。
+	if passwd != "" {
+		auth = append(auth, ss.sshPasswordMethod(passwd))
+	}
+
+	return auth
 }
 
-func (ss *SSH) readFile(name string) string {
+func fileExist(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil || os.IsExist(err)
+}
+
+// 使用 pk认证， pk路径为 "/root/.ssh/id_rsa", pk有密码和无密码在这里面验证
+func (ss *SSH) sshPrivateKeyMethod(pkFile, pkPassword string) (am ssh.AuthMethod, err error) {
+	pkData := ss.readFile(pkFile)
+	var pk ssh.Signer
+	if pkPassword == "" {
+		pk, err = ssh.ParsePrivateKey(pkData)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		bufPwd := []byte(pkPassword)
+		pk, err = ssh.ParsePrivateKeyWithPassphrase(pkData, bufPwd)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return ssh.PublicKeys(pk), nil
+}
+
+func (ss *SSH) sshPasswordMethod(passwd string) ssh.AuthMethod {
+	return ssh.Password(passwd)
+}
+
+// readFile 从文件读取privateKey， 并返回[]byte 无需返回string。
+// 直接返回[]byte， 避免重复 []byte -> string -> []byte
+func (ss *SSH) readFile(name string) []byte {
 	content, err := ioutil.ReadFile(name)
 	if err != nil {
-		logger.Error("[globals] read file err is : %s", err)
+		logger.Error("[globals] read %s file err is : %s", name, err)
 		os.Exit(1)
 	}
-	return string(content)
+	return content
 }
 
 func (ss *SSH) addrReformat(host string) string {

--- a/pkg/sshcmd/sshutil/scp.go
+++ b/pkg/sshcmd/sshutil/scp.go
@@ -168,8 +168,7 @@ func (ss *SSH) sftpConnect(host string) (*sftp.Client, error) {
 		err          error
 	)
 	// get auth method
-	auth = make([]ssh.AuthMethod, 0)
-	auth = append(auth, ss.sshAuthMethod(ss.Password, ss.PkFile))
+	auth = ss.sshAuthMethod(ss.Password, ss.PkFile, ss.PkPassword)
 
 	clientConfig = &ssh.ClientConfig{
 		User:    ss.User,

--- a/pkg/sshcmd/sshutil/ssh.go
+++ b/pkg/sshcmd/sshutil/ssh.go
@@ -78,11 +78,11 @@ func (ss *SSH) CmdAsync(host string, cmd string) error {
 	doneout := make(chan bool, 1)
 	doneerr := make(chan bool, 1)
 	go func() {
-		readPipe(host,stderr,true)
+		readPipe(host, stderr, true)
 		doneerr <- true
 	}()
 	go func() {
-		readPipe(host, stdout,false)
+		readPipe(host, stdout, false)
 		doneout <- true
 	}()
 	<-doneerr

--- a/pkg/sshcmd/sshutil/types.go
+++ b/pkg/sshcmd/sshutil/types.go
@@ -3,8 +3,9 @@ package sshutil
 import "time"
 
 type SSH struct {
-	User     string
-	Password string
-	PkFile   string
-	Timeout  *time.Duration
+	User       string
+	Password   string
+	PkFile     string
+	PkPassword string
+	Timeout    *time.Duration
 }

--- a/version/version.go
+++ b/version/version.go
@@ -6,8 +6,8 @@ import (
 )
 
 var (
-	Version    = "latest"
-	Build      = ""
+	Version   = "latest"
+	Build     = ""
 	BuildTime = ""
 	// VersionStr = fmt.Sprintf("sealos version %v, build %v %v", Version, Build, runtime.Version())
 	VersionStr = fmt.Sprintf("sealos version %v, build %v %v, Build Time : %v", Version, Build, runtime.Version(), BuildTime)


### PR DESCRIPTION
0. 默认pk文件是`/root/.ssh/id_rsa`. 
1. 验证先判断 pk 文件 , 如果能够获取`ssh.AuthMethod` , 则添加 至 auth. 
2. 验证 password. 如果 password不为空, 则添加  `ssh.AuthMethod` 至auth.

1,2 验证都获取到了 `ssh.AuthMethod` 进入验证阶段, 这部分逻辑没变. 
ps: 
判断pk文件的时候, 如果pk文件有密码, 则需添加 `--pk-passwd`命令行参数. 默认为空. 
如果用户只想用密码验证.  但是`/root/.ssh/id_rsa` 这个文件不存在, 则直接返回auth.