### PR TITLE
ssh 验证优化.修复load未考虑pk-password

### DIFF
--- a/install/config.go
+++ b/install/config.go
@@ -124,6 +124,7 @@ func (c *SealConfig) Load(path string) (err error) {
 	SSHConfig.User = c.User
 	SSHConfig.Password = c.Passwd
 	SSHConfig.PkFile = c.PrivateKey
+	SSHConfig.PkPassword = c.PkPassword
 	ApiServer = c.ApiServerDomian
 	VIP = c.VIP
 	PkgUrl = c.PkgURL


### PR DESCRIPTION
load config时, 未考虑pk-passwod.  #395 