### PR TITLE
#399  install -f - support stdin

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -15,27 +15,52 @@
 package cmd
 
 import (
+	"bytes"
 	"github.com/fanux/sealos/install"
 	"github.com/spf13/cobra"
+	"github.com/wonderivan/logger"
+	"io/ioutil"
 	"os"
 )
 
-var AppURL  string
+var (
+	AppURL         string
+	installExample string = `
+	# Apply the configuration in values.yaml to a kubernetes Cluster.
+	sealos install --pkg-url /root/dashboard.tar -f values.yaml
+
+	# Apply the yaml passed into stdin to a kubenertes Cluster.
+ 	cat values.yaml | sealos install --pkg-url /root/dashboard.tar -f -
+	
+	# Set the WorkDir for your Package
+	sealos install --pkg-url /root/dashboard.tar  -w /data
+`
+)
 
 // installCmd represents the install command
 var installCmd = &cobra.Command{
 	Use:   "install",
 	Short: "install kubernetes apps, like dashboard prometheus ..",
-	Long:  `sealos install --pkg-url /root/dashboard.tar  --workdir /data \
+	Long: `sealos install --pkg-url /root/dashboard.tar  --workdir /data \
 -f /root/values.yaml -c /root/config`,
+	Example: installExample,
 	Run: func(cmd *cobra.Command, args []string) {
+		// 处理stdin
+		if install.Values == "-" {
+			err := ReadStdin()
+			if err != nil {
+				logger.Error(err)
+				os.Exit(-1)
+			}
+		}
 		install.AppInstall(AppURL)
 	},
 	PreRun: func(cmd *cobra.Command, args []string) {
-		if install.ExitInstallCase(AppURL)  {
+		if install.ExitInstallCase(AppURL) {
 			cmd.Help()
 			os.Exit(install.ErrorExitOSCase)
 		}
+
 	},
 }
 var name string
@@ -45,6 +70,15 @@ func init() {
 
 	installCmd.Flags().StringVar(&AppURL, "pkg-url", "", "http://store.lameleg.com/prometheus.tar.gz download offline plugins package url, or file localtion ex. /root/prometheus.tar.gz")
 	installCmd.Flags().StringVarP(&install.Workdir, "workdir", "w", "/root/", "workdir for install package home ex.  sealos install --pkg-url dashboard.tar --workdir /data")
-	installCmd.Flags().StringVarP(&install.PackageConfig, "pkg-config","c", "", `packageConfig for install package config  ex. sealos install --pkg-url dashboard.tar -c config`)
-	installCmd.Flags().StringVarP(&install.Values, "values","f", "", "values for  install package values.yaml , you know what you did .ex. sealos install --pkg-url dashboard.tar -f values.yaml")
+	installCmd.Flags().StringVarP(&install.PackageConfig, "pkg-config", "c", "", `packageConfig for install package config  ex. sealos install --pkg-url dashboard.tar -c config`)
+	installCmd.Flags().StringVarP(&install.Values, "values", "f", "", "values for  install package values.yaml , you know what you did .ex. sealos install --pkg-url dashboard.tar -f values.yaml")
+}
+
+func ReadStdin() error {
+	var b bytes.Buffer
+	_, err := b.ReadFrom(os.Stdin)
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(install.Workdir+"values.yaml", b.Bytes(), 0660)
 }

--- a/install/install.go
+++ b/install/install.go
@@ -183,7 +183,10 @@ func (r *RunOnEveryNodes) Run(config SealConfig, url, pkgName, workdir string) {
 
 	nodes := append(config.Masters, config.Nodes...)
 	// values.yaml 存在， 则将 values.yaml复制到各个节点。
-	if Values != "" {
+	if Values == "-" {
+		// 处理 stdin
+		SendPackage(workdir+"values.yaml", nodes, workspace, nil, nil)
+	} else if Values != "" {
 		SendPackage(Values, nodes, workspace, nil, nil)
 	}
 	SendPackage(url, nodes, workspace, nil, nil)

--- a/install/utils.go
+++ b/install/utils.go
@@ -56,9 +56,9 @@ func ExitInitCase() bool {
 }
 
 func ExitInstallCase(pkgUrl string) bool {
-	// values.yaml 使用了-f 但是文件不存在.
-	if Values != "" && !FileExist(Values) {
-		logger.Error("your values File is not exist, Please check your Values.yaml is exist")
+	// values.yaml 使用了-f 但是文件不存在. 并且不使用 stdin
+	if Values != "-" && !FileExist(Values) && Values !="" {
+		logger.Error("your values File is not exist and you have no stdin input, Please check your Values.yaml is exist")
 		return true
 	}
 	// PackageConfig 使用了-c 但是文件不存在


### PR DESCRIPTION
sealos  install -f  时。 增加stdin读取。  #399 

功能为：   当读取stdin时， 在`workdir`生成 `values.yaml `。 然后复制到各节点。 
当读取文件时， 直接复制到个节点。
当不带参数 -f 时。 默认使用 `tar`包里面的默认` values.yaml `。

tips： 
感觉需要在 `CONFIG `文件在添加一句 `APPLY kubectl apply -f  values.yaml` . 不然用户还得定义这一行。 