### PR TITLE
Only append to /etc/hosts if entry not exists

### DIFF
--- a/install/init.go
+++ b/install/init.go
@@ -124,7 +124,7 @@ func (s *SealosInstaller) InstallMaster0() {
 	s.SendKubeConfigs(s.Masters, true)
 
 	//master0 do sth
-	cmd := fmt.Sprintf("echo %s %s >> /etc/hosts", IpFormat(s.Masters[0]), ApiServer)
+	cmd := fmt.Sprintf("grep -qF '%s %s' /etc/hosts || echo %s %s >> /etc/hosts", IpFormat(s.Masters[0]), ApiServer)
 	_ = SSHConfig.CmdAsync(s.Masters[0], cmd)
 
 	cmd = s.Command(Version, InitMaster)


### PR DESCRIPTION
If `sealos init` fails and runs multiple times, there will be duplicate entries in /etc/hosts .
