### PR TITLE
fix ETCD CaCert or key file is not exist occurs panic

### DIFF
--- a/cmd/etcd.go
+++ b/cmd/etcd.go
@@ -51,12 +51,12 @@ func NewEtcdCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "etcd <subcommand>",
 		Short:   "Simplest way to snapshot/restore your kubernets etcd",
-		Long:    `etcd save --name snapshot`,
+		Long:    `sealos etcd save --name snapshot`,
 		Example: exampleCmd,
 	}
-	cmd.AddCommand(NewEtcdSaveComand())
-	cmd.AddCommand(NewEtcdRestoreComand())
-	cmd.AddCommand(NewEtcdHealthComand())
+	cmd.AddCommand(NewEtcdSaveCommand())
+	cmd.AddCommand(NewEtcdRestoreCommand())
+	cmd.AddCommand(NewEtcdHealthCommand())
 	//cmd.Flags().BoolVar(&install.EtcdSnapshotSave, "snap-save", false, "snapshot your kubernets etcd ")
 	//cmd.Flags().BoolVar(&install.EtcdRestore, "snap-restore", false, "restore your kubernets etcd")
 	//cmd.Flags().BoolVar(&install.EtcdHealthCheck, "health", false, "check your kubernets etcd")
@@ -67,7 +67,7 @@ func NewEtcdCommand() *cobra.Command {
 
 	return cmd
 }
-func NewEtcdSaveComand() *cobra.Command {
+func NewEtcdSaveCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "save",
 		Short: "Stores an etcd node backend snapshot to a given file",
@@ -85,7 +85,7 @@ func NewEtcdSaveComand() *cobra.Command {
 	return cmd
 }
 
-func NewEtcdRestoreComand() *cobra.Command {
+func NewEtcdRestoreCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "restore",
 		Short: "Restores an etcd member snapshot to an etcd directory",
@@ -97,7 +97,7 @@ func NewEtcdRestoreComand() *cobra.Command {
 	return cmd
 }
 
-func NewEtcdHealthComand() *cobra.Command {
+func NewEtcdHealthCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "health",
 		Short: "test your etcd status",

--- a/install/etcd_restore.go
+++ b/install/etcd_restore.go
@@ -28,6 +28,10 @@ func RandStringRunes(n int) string {
 
 func GetRestoreFlags() *EtcdFlags {
 	e := &EtcdFlags{}
+	if !e.CertFileExist() {
+		logger.Error("ETCD CaCert or key file is not exist.")
+		os.Exit(1)
+	}
 	err := e.Load("")
 	if err != nil {
 		logger.Error(err)

--- a/install/etcd_save.go
+++ b/install/etcd_save.go
@@ -32,6 +32,10 @@ func GetEtcdBackFlags() *EtcdFlags {
 		ip, endpoint string
 	)
 	e := &EtcdFlags{}
+	if !e.CertFileExist() {
+		logger.Error("ETCD CaCert or key file is not exist.")
+		os.Exit(1)
+	}
 	err := e.Load("")
 	if err != nil {
 		logger.Error(err)
@@ -256,4 +260,9 @@ func (e *EtcdFlags) HealthCheck() {
 	if errs {
 		logger.Error("unhealthy cluster")
 	}
+}
+
+// CertFileExist if cert file is exist return true
+func (e *EtcdFlags) CertFileExist() bool {
+	return FileExist(EtcdCacart) && FileExist(EtcdCert) && FileExist(EtcdKey)
 }

--- a/install/init.go
+++ b/install/init.go
@@ -124,7 +124,7 @@ func (s *SealosInstaller) InstallMaster0() {
 	s.SendKubeConfigs(s.Masters, true)
 
 	//master0 do sth
-	cmd := fmt.Sprintf("grep -qF '%s %s' /etc/hosts || echo %s %s >> /etc/hosts", IpFormat(s.Masters[0]), ApiServer)
+	cmd := fmt.Sprintf("grep -qF '%s %s' /etc/hosts || echo %s %s >> /etc/hosts", IpFormat(s.Masters[0]), ApiServer, IpFormat(s.Masters[0]), ApiServer)
 	_ = SSHConfig.CmdAsync(s.Masters[0], cmd)
 
 	cmd = s.Command(Version, InitMaster)


### PR DESCRIPTION
[SKIP CI]seaols: 一句话简短描述该PR内容
fix ETCD CaCert or key file is not exist occurs panic. @cuisongliu 
```
$ ./sealos etcd health
17:53:53 [EROR] [etcd_save.go:211] open /root/.sealos/pki/etcd/healthcheck-client.crt: permission denied
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x166141e]

goroutine 127 [running]:
github.com/fanux/sealos/install.(*EtcdFlags).HealthCheck.func1(0xc0002c3e00, 0xc0003d8240, 0x0)
        /home/louis/go/src/github.com/oldthreefeng/sealos/install/etcd_save.go:221 +0x6e
created by github.com/fanux/sealos/install.(*EtcdFlags).HealthCheck
        /home/louis/go/src/github.com/oldthreefeng/sealos/install/etcd_save.go:219 +0x23c

```