### PR TITLE
refactor exec andadd test 

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -23,11 +23,11 @@ import (
 // execCmd represents the exec command
 var (
 	exampleExecCmd = `
-	# exec cmd by label or nodes.  when --label and --node is Exist, get Intersection of both.
+	# exec cmd by label or nodes.  when --label and --node is Exist, get Union of both.
 	sealos exec --cmd "mkdir /data" --label node-role.kubernetes.io/master= --node 192.168.0.2
-	sealos exec --cmd "mkdir /data" --node 192.168.0.2
+	sealos exec --cmd "mkdir /data" --node 192.168.0.2 --nodes dev-k8s-mater
 	
-	# exec copy src file to dst by label or nodes. when --label and --node is Exist, get Intersection of both.
+	# exec copy src file to dst by label or nodes. when --label and --node is Exist, get Union of both.
 	sealos exec --src /data/foo --dst /root/foo --label node-role.kubernetes.io/master=""
 	sealos exec --src /data/foo --dst /root/foo --node 192.168.0.2
 `
@@ -46,7 +46,7 @@ func init() {
 	execCmd.Flags().StringVar(&install.Dst, "dst", "", "dest file location")
 	execCmd.Flags().StringVar(&install.ExecCommand, "cmd", "", "exec command string")
 	execCmd.Flags().StringVar(&install.Label, "label", "", "kubernetes labels like node-role.kubernetes.io/master=")
-	execCmd.Flags().StringSliceVar(&install.ExecNode, "node", []string{}, "node ip")
+	execCmd.Flags().StringSliceVar(&install.ExecNode, "node", []string{}, "node ip or hostname in kubernetes")
 
 }
 

--- a/install/exec.go
+++ b/install/exec.go
@@ -13,8 +13,6 @@ type ExecFlag struct {
 	Cmd      string
 	Label    string
 	ExecNode []string
-	// map["hostname"] -> ip
-	Nodes map[string]string
 	SealConfig
 }
 
@@ -43,19 +41,17 @@ func GetExecFlag() *ExecFlag {
 	// logger.Info("get label", Label)
 	e.Label = Label
 	e.Cmd = ExecCommand
-	e.ExecNode = ExecNode
 
-	// if use label， we need to re-init ExecNode which Flag --node is not set，
-	// we must put all nodes to ExecNode. so we can map the ip and hostname.
-	if e.IsUseLabeled() && !e.IsUseNode() {
-		ExecNode = append(ExecNode, MasterIPs...)
-		ExecNode = append(ExecNode, NodeIPs...)
+	// change labels ==> to ip
+	k8sClient, err := k8s.NewClient(k8s.KubeDefaultConfigPath, nil)
+	if err != nil {
+		logger.Error("get k8s client err: ", err)
+		os.Exit(ErrorExitOSCase)
 	}
-	// make to create non-nil map， nil map assign will panic
-	e.Nodes = make(map[string]string, len(ExecNode))
-	for _, node := range ExecNode {
-		hostname := SSHConfig.CmdToString(node, "hostname", "")
-		e.Nodes[hostname] = node
+	e.ExecNode, err = k8s.TransToIP(k8sClient, Label, ExecNode)
+	if err != nil {
+		logger.Error("get ips err: ", err)
+		os.Exit(ErrorExitOSCase)
 	}
 	return e
 }
@@ -70,7 +66,7 @@ func (e *ExecFlag) IsUseCmd() bool {
 	return e.Cmd != ""
 }
 
-// IsUseCmd return true when you want to copy file
+// IsUseCopy return true when you want to copy file
 func (e *ExecFlag) IsUseCopy() bool {
 	return FileExist(e.Src) && e.Dst != ""
 }
@@ -82,38 +78,18 @@ func (e *ExecFlag) IsUseNode() bool {
 
 // Copy is cp src file to dst file
 func (e *ExecFlag) Copy() {
-	// this case when use by label . we need a flag to set the --node is not used, in case of running twice By label
-	if e.IsUseNode() && !e.IsUseLabeled() {
-		e.copyByNode()
-	}
-	if e.IsUseLabeled() {
-		err := e.copyByLabel()
-		if err != nil {
-			logger.Error("copyByLabel err: ", err)
-			os.Exit(ErrorExitOSCase)
-		}
-	}
+	e.copyByNodeIp()
 }
 
 // Exec is cp src file to dst file
 func (e *ExecFlag) Exec() {
-	// this case when use by label . we need a flag to set the --node is not used, in case of running twice By label
-	if e.IsUseNode() && !e.IsUseLabeled() {
-		e.execByNode()
-	}
-	if e.IsUseLabeled() {
-		err := e.execByLabel()
-		if err != nil {
-			logger.Error("execByLabel err: ", err)
-			os.Exit(ErrorExitOSCase)
-		}
-	}
+	e.execByNodeIp()
 }
 
-// copyByNode is cp src file to dst file
-func (e *ExecFlag) copyByNode() {
+// copyByNodeIp is cp src file to dst file
+func (e *ExecFlag) copyByNodeIp() {
 	var wg sync.WaitGroup
-	for _, n := range e.Nodes {
+	for _, n := range e.ExecNode {
 		wg.Add(1)
 		go func(node string) {
 			defer wg.Done()
@@ -128,10 +104,10 @@ func (e *ExecFlag) copyByNode() {
 	wg.Wait()
 }
 
-// execByNode is exec cmd in Node
-func (e *ExecFlag) execByNode() {
+// execByNodeIp is exec cmd in Node
+func (e *ExecFlag) execByNodeIp() {
 	var wg sync.WaitGroup
-	for _, n := range e.Nodes {
+	for _, n := range e.ExecNode {
 		wg.Add(1)
 		go func(node string) {
 			defer wg.Done()
@@ -139,47 +115,4 @@ func (e *ExecFlag) execByNode() {
 		}(n)
 	}
 	wg.Wait()
-}
-
-func (e *ExecFlag) getNodesByLabel() ([]string, error) {
-	k8sClient, err := k8s.NewClient(k8s.KubeDefaultConfigPath, nil)
-	if err != nil {
-		return nil, err
-	}
-	return k8s.GetNodeByLabel(k8sClient, e.Label)
-}
-
-// execByNode is exec cmd by Node
-func (e *ExecFlag) execByLabel() error {
-	hosts, err := e.getNodesByLabel()
-	if err != nil {
-		return err
-	}
-	for _, hostname := range hosts {
-		// logger.Info(hostname)
-		if node, ok := e.Nodes[hostname]; ok {
-			CmdWorkSpace(node, e.Cmd, TMPDIR)
-		}
-	}
-	return nil
-}
-
-// copyByNode is copy file by label
-func (e *ExecFlag) copyByLabel() error {
-	hosts, err := e.getNodesByLabel()
-	if err != nil {
-		return err
-	}
-	for _, hostname := range hosts {
-		// 说明这个是需要操作的。
-		if node, ok := e.Nodes[hostname]; ok {
-			// 存在就直接跳过。 不存在才执行
-			if SSHConfig.IsFileExist(node, e.Dst) {
-				logger.Info("[%s] is exist on remote host [%s].skip...", e.Dst, node)
-				continue
-			}
-			SSHConfig.CopyLocalToRemote(node, e.Src, e.Dst)
-		}
-	}
-	return nil
 }

--- a/k8s/node.go
+++ b/k8s/node.go
@@ -113,6 +113,9 @@ func GetNodeNameByLabel(k8sClient *kubernetes.Clientset, label string) ([]string
 // GetNodeIpByLabel is is get node ip by label
 func GetNodeIpByLabel(k8sClient *kubernetes.Clientset, label string) ([]string, error) {
 	var ips []string
+	if label == "" {
+		return ips, nil
+	}
 	nodes, err := GetNodeListByLabel(k8sClient, label)
 	if err != nil {
 		return nil, err

--- a/k8s/utlis.go
+++ b/k8s/utlis.go
@@ -1,0 +1,80 @@
+package k8s
+
+import (
+	"strings"
+)
+
+func getHostnameAndIp(node []string) ([]string, []string) {
+	var resHost, resIp []string
+	if len(node) == 0 {
+		return node, node
+	}
+	for _, n := range node {
+		if !IsIpv4(n) {
+			resHost = append(resHost, n)
+		} else {
+			resIp = append(resIp, n)
+		}
+	}
+	return resHost, resIp
+}
+
+func IsIpv4(ip string) bool {
+	//matched, _ := regexp.MatchString("((2(5[0-5]|[0-4]\\d))|[0-1]?\\d{1,2})(\\.((2(5[0-5]|[0-4]\\d))|[0-1]?\\d{1,2})){3}", ip)
+
+	arr := strings.Split(ip, ".")
+	if len(arr) != 4 {
+		return false
+	}
+	for _, v := range arr {
+		if v == "" {
+			return false
+		}
+		if len(v) > 1 && v[0] == '0' {
+			return false
+		}
+		num := 0
+		for _, c := range v {
+			if c >= '0' && c <= '9' {
+				num = num*10 + int(c-'0')
+			} else {
+				return false
+			}
+		}
+		if num > 255 {
+			return false
+		}
+	}
+	return true
+}
+
+// remove is remove b in a []string
+func remove(a []string, b string) []string {
+	if len(a) == 0 {
+		return a
+	}
+	for i, v := range a {
+		if v == b {
+			a = append(a[:i], a[i+1:]...)
+			return remove(a, b)
+			break
+		}
+	}
+	return a
+}
+
+// removeRep is Deduplication []string
+func removeRep(a []string) []string {
+	if len(a) == 0 {
+		return a
+	}
+	res := make([]string, 0, len(a))
+	tmp := map[string]struct{}{}
+	for _, v := range a {
+		if _, ok := tmp[v]; !ok {
+			tmp[v] = struct{}{}
+			res = append(res, v)
+		}
+	}
+	return res
+}

--- a/k8s/utlis_test.go
+++ b/k8s/utlis_test.go
@@ -1,0 +1,87 @@
+package k8s
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestIsIpv4(t *testing.T) {
+	type args struct {
+		ip string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{"test01", args{
+			"192.168.0.1",
+		}, true},
+		{"test02", args{
+			"192.168.00.1",
+		}, false},
+		{"test03", args{
+			"dev-master",
+		}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsIpv4(tt.args.ip); got != tt.want {
+				t.Errorf("IsIp() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_remove(t *testing.T) {
+	type args struct {
+		a []string
+		b string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{"test01", args{
+			a: []string{"123", "245", "345"},
+			b: "123",
+		}, []string{"245", "345"}},
+		{"test02", args{
+			a: []string{"123", "245", "345", "123", "245", "345", "123", "245", "345"},
+			b: "123",
+		}, []string{"245", "345", "245", "345", "245", "345"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := remove(tt.args.a, tt.args.b); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("remove() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_removeRep(t *testing.T) {
+	type args struct {
+		a []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{"test01", args{
+			a: []string{"123", "245", "345", "345"},
+		}, []string{"123", "245", "345"}},
+		{"test02", args{
+			a: []string{"123", "245", "345", "123", "245", "345", "123", "245", "345"},
+		}, []string{"123", "245", "345"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := removeRep(tt.args.a); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("removeRep() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/k8s/utlis_test.go
+++ b/k8s/utlis_test.go
@@ -2,6 +2,9 @@ package k8s
 
 import (
 	"reflect"
+	"regexp"
+	"strconv"
+	"strings"
 	"testing"
 )
 
@@ -83,5 +86,124 @@ func Test_removeRep(t *testing.T) {
 				t.Errorf("removeRep() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func Test_removeByUse(t *testing.T) {
+	type args struct {
+		a []string
+		b string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{"test01", args{
+			a: []string{"123", "245", "345"},
+			b: "123",
+		}, []string{"245", "345"}},
+		{"test02", args{
+			a: []string{"123", "245", "345", "123", "245", "345", "123", "245", "345"},
+			b: "123",
+		}, []string{"245", "345", "245", "345", "245", "345"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := func(a []string, b string) []string {
+				if len(a) == 0 {
+					return a
+				}
+				res := a[:0]
+				for _, v := range a {
+					if v != b {
+						res = append(res, v)
+					}
+				}
+				return res
+			}(tt.args.a, tt.args.b); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("remove() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Benchmark_remove(b *testing.B) {
+	b.ResetTimer()
+	origin := []string{"123", "245", "345", "123", "245", "345", "123", "245", "345"}
+	for i:=0; i<b.N;i++ {
+		remove(origin, "123")
+	}
+}
+
+func Benchmark_removeByUse(b *testing.B) {
+	b.ResetTimer()
+	origin := []string{"123", "245", "345", "123", "245", "345", "123", "245", "345"}
+	for i:=0; i<b.N;i++ {
+		func(a []string, b string) []string {
+			if len(a) == 0 {
+				return a
+			}
+			res := a[:0]
+			for _, v := range a {
+				if v != b {
+					res = append(res, v)
+				}
+			}
+			return res
+		}(origin, "123")
+	}
+}
+
+func Benchmark_removeRep(b *testing.B) {
+	b.ResetTimer()
+	origin := []string{"123", "245", "345", "123", "245", "345", "123", "245", "345"}
+	for i:=0; i<b.N;i++ {
+		removeRep(origin)
+	}
+}
+
+func BenchmarkIsIpv4(b *testing.B) {
+	b.ResetTimer()
+	origin := "192.168.00.1"
+	for i:=0; i<b.N;i++ {
+		IsIpv4(origin)
+	}
+}
+
+func BenchmarkIsIpv42(b *testing.B) {
+	b.ResetTimer()
+	origin := "192.168.00.1"
+	for i:=0; i<b.N;i++ {
+		_, _ = regexp.MatchString("((2(5[0-5]|[0-4]\\d))|[0-1]?\\d{1,2})(\\.((2(5[0-5]|[0-4]\\d))|[0-1]?\\d{1,2})){3}", origin)
+	}
+}
+
+func BenchmarkIsIpv43(b *testing.B) {
+	b.ResetTimer()
+	origin := "192.168.00.1"
+	for i:=0; i<b.N;i++ {
+		func(ip string) bool {
+			strs := strings.Split(ip, ".")
+			if len(strs) != 4 {
+				return false
+			}
+			for _, s := range strs {
+				if len(s) == 0 || (len(s) > 1 && s[0] == '0') {
+					return false
+				}
+				if s[0] < '0' || s[0] > '9' {
+					return false
+				}
+				n, err := strconv.Atoi(s)
+				if err != nil {
+					return false
+				}
+				if n < 0 || n > 255 {
+					return false
+				}
+			}
+			return true
+		} (origin)
 	}
 }

--- a/pkg/sshcmd/sshutil/scp_test.go
+++ b/pkg/sshcmd/sshutil/scp_test.go
@@ -1,0 +1,74 @@
+package sshutil
+
+import (
+	"github.com/wonderivan/logger"
+	"testing"
+)
+
+func TestSSHCopyLocalToRemote(t *testing.T) {
+	type args struct {
+		host       string
+		localPath  string
+		remotePath string
+	}
+	var (
+		host = "192.168.160.243"
+		ssh  = SSH{
+			User:       "root",
+			Password:   "centos",
+			PkFile:     "",
+			PkPassword: "",
+			Timeout:    nil,
+		}
+	)
+	tests := []struct {
+		name   string
+		fields SSH
+		args   args
+	}{
+		{"test for copy file to remote server", ssh, args{
+			host,
+			"/home/louis/temp/01",
+			"/data/temp/01",
+		}},
+		{"test copy for file when local file is not exist", ssh, args{
+			host,
+			// local file  001 is not exist.
+			"/home/louis/temp/001",
+			"/data/temp/01",
+		}},
+		{"test copy dir to remote server", ssh, args{
+			host,
+			"/home/louis/temp",
+			"/data/temp01",
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ss := &SSH{
+				User:       tt.fields.User,
+				Password:   tt.fields.Password,
+				PkFile:     tt.fields.PkFile,
+				PkPassword: tt.fields.PkPassword,
+				Timeout:    tt.fields.Timeout,
+			}
+
+			if !fileExist(tt.args.localPath) {
+				logger.Error("local filepath is not exit")
+				return
+			}
+			if ss.IsFileExist(host, tt.args.remotePath) {
+				logger.Error("remote filepath is exit")
+				return
+			}
+			// test copy dir
+			ss.CopyLocalToRemote(tt.args.host, tt.args.localPath, tt.args.remotePath)
+
+			// test the copy result
+			ss.Cmd(tt.args.host, "ls -lh "+tt.args.remotePath)
+
+			// rm remote file
+			ss.Cmd(tt.args.host, "rm -rf "+tt.args.remotePath)
+		})
+	}
+}


### PR DESCRIPTION
[SKIP CI]seaols: 一句话简短描述该PR内容
这版支持了 `--node hostname` .  k8s 里面操作`node`对象感觉有点生疏.  ~~从里面获取资源用了`n个for`循环~~  
@fanux  ~~对`k8s里面node`对象的操作有好的推荐么?  如果nodes节点过多, 感觉这个算法就不行了.~~
实现如下: 
使用Get方法, 通过`nodename`直接找到定位到node节点.
```
node, err := k8sClient.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
```
使用ListOptions, 通过`labelSelector`直接定位到nodeList节点
```
func GetNodeListByLabel(k8sClient *kubernetes.Clientset, label string) (*v1.NodeList, error) {
	listOption := &metav1.ListOptions{LabelSelector: label}
	return k8sClient.CoreV1().Nodes().List(context.TODO(), *listOption)
}
```
避免使用for循环来找. 效率太低且难看

主要改版点是 , 将 `--label , --node hostname` 所关联的对象全部转为ip, 以ip为基点去执行. 避免了各种判断
在转换过程中, 必不可少会导致去重和删除不必要的信息. 
以下是测试过程的信息. 

<details><summary><code>1. Use --label to exec cmd </code> Output</summary><br><pre>
$ ./sealos exec --cmd "hostname "  --label beta.kubernetes.io/arch=amd64  
19:09:35 [INFO] [ssh.go:57] [ssh][192.168.0.88] cd /tmp && hostname 
19:09:35 [INFO] [ssh.go:57] [ssh][192.168.0.31] cd /tmp && hostname 
19:09:35 [INFO] [ssh.go:57] [ssh][192.168.0.30] cd /tmp && hostname 
19:09:35 [INFO] [ssh.go:57] [ssh][192.168.0.65] cd /tmp && hostname 
19:09:35 [INFO] [ssh.go:50] [192.168.0.88] server88-new
19:09:35 [INFO] [ssh.go:50] [192.168.0.30] huohua-test
19:09:35 [INFO] [ssh.go:50] [192.168.0.65] server65
19:09:36 [INFO] [ssh.go:50] [192.168.0.31] k8s-master
</pre></details>

<details><summary><code>2. Use --node to exec cmd </code> Output</summary><br><pre>
$ ./sealos exec --cmd "hostname -i"  --node huohua-test --node 192.168.0.65 
19:20:47 [INFO] [ssh.go:57] [ssh][192.168.0.30] cd /tmp && hostname -i
19:20:47 [INFO] [ssh.go:57] [ssh][192.168.0.65] cd /tmp && hostname -i
19:20:47 [INFO] [ssh.go:50] [192.168.0.30] 192.168.0.30
19:20:47 [INFO] [ssh.go:50] [192.168.0.65] 192.168.0.65

</pre></details>

<details><summary><code>3. Use --node & --label  to exec cmd  </code> Output</summary><br><pre>
$ ./sealos exec --cmd "hostname -i"  --node huohua-test  --label node-role.kubernetes.io/master=  
19:21:44 [INFO] [ssh.go:57] [ssh][192.168.0.30] cd /tmp && hostname -i
19:21:44 [INFO] [ssh.go:57] [ssh][192.168.0.31] cd /tmp && hostname -i
19:21:44 [INFO] [ssh.go:50] [192.168.0.30] 192.168.0.30
19:21:45 [INFO] [ssh.go:50] [192.168.0.31] 192.168.0.31

</pre></details>

<details><summary><code>4. Use --node & --label  to exec cmd & copy files  </code> Output</summary><br><pre>
$ ./sealos exec --cmd "ls -lh /data/01.txt" --src /root/01.txt --dst /data/01.txt  --node huohua-test  --label node-role.kubernetes.io/master=  
19:23:01 [INFO] [ssh.go:12] [ssh][192.168.0.30] ls -l /data/01.txt 2>/dev/null |wc -l
19:23:01 [INFO] [ssh.go:12] [ssh][192.168.0.31] ls -l /data/01.txt 2>/dev/null |wc -l
19:23:01 [DEBG] [ssh.go:24] [ssh][192.168.0.30]command result is: 0

19:23:02 [INFO] [scp.go:328] [ssh]transfer [/root/01.txt] total size is: 2.11MB ;speed is 2MB
19:23:02 [DEBG] [ssh.go:24] [ssh][192.168.0.31]command result is: 0

19:23:02 [INFO] [scp.go:328] [ssh]transfer [/root/01.txt] total size is: 2.11MB ;speed is 2MB
19:23:02 [INFO] [ssh.go:57] [ssh][192.168.0.30] cd /tmp && ls -lh /data/01.txt
19:23:02 [INFO] [ssh.go:57] [ssh][192.168.0.31] cd /tmp && ls -lh /data/01.txt
19:23:02 [INFO] [ssh.go:50] [192.168.0.30] -rw-r--r-- 1 root root 2.2M 9月   4 19:23 /data/01.txt
19:23:03 [INFO] [ssh.go:50] [192.168.0.31] -rw-r--r--. 1 root root 2.2M Sep  4 19:23 /data/01.txt

</pre></details>

<details><summary><code>5. Use --node & --label  to exec cmd & copy dir  </code> Output</summary><br><pre>
$ ./sealos exec --cmd "ls -lh /data/test" --src /root/test --dst /data/test  --node huohua-test  --label node-role.kubernetes.io/master=  
19:24:24 [INFO] [ssh.go:12] [ssh][192.168.0.30] ls -l /data/test 2>/dev/null |wc -l
19:24:24 [INFO] [ssh.go:12] [ssh][192.168.0.31] ls -l /data/test 2>/dev/null |wc -l
19:24:24 [DEBG] [ssh.go:24] [ssh][192.168.0.30]command result is: 0

19:24:24 [INFO] [scp.go:328] [ssh]transfer [/root/test/crontab.yaml] total size is: 1.19KB ;speed is 1KB
19:24:24 [INFO] [scp.go:328] [ssh]transfer [/root/test/crontab.yaml.bak] total size is: 2.23KB ;speed is 2KB
19:24:24 [DEBG] [ssh.go:24] [ssh][192.168.0.31]command result is: 0

19:24:25 [INFO] [scp.go:328] [ssh]transfer [/root/test/crontab.yaml] total size is: 1.19KB ;speed is 1KB
19:24:25 [INFO] [scp.go:328] [ssh]transfer [/root/test/crontab.yaml.bak] total size is: 2.23KB ;speed is 2KB
19:24:25 [INFO] [ssh.go:57] [ssh][192.168.0.30] cd /tmp && ls -lh /data/test
19:24:25 [INFO] [ssh.go:57] [ssh][192.168.0.31] cd /tmp && ls -lh /data/test
19:24:25 [INFO] [ssh.go:50] [192.168.0.30] 总用量 8.0K
19:24:25 [INFO] [ssh.go:50] [192.168.0.30] -rw-r--r-- 1 root root 1.2K 9月   4 19:24 crontab.yaml
19:24:25 [INFO] [ssh.go:50] [192.168.0.31] total 8.0K

</pre></details>


<details><summary><code>6. Use --label if label not exist  </code> Output</summary><br><pre>
$ ./sealos exec --cmd "hostname -i"  --node huohua-test  --label node-role.kubernete.
12:48:25 [EROR] [exec.go:53] get ips err:  unable to parse requirement: invalid label key "node-role.kubernete.": name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')

$ ./sealos exec --cmd "hostname -i"  --node huohua-test  --label node-role.kubernete                                                          
12:48:42 [EROR] [exec.go:53] get ips err:  label node-role.kubernete is not fount in kubernetes nodes

</pre></details>

<details><summary><code>7. Use --node if node  not exist in kuernetes  </code> Output</summary><br><pre>

12:50:05 [INFO] [ssh.go:50] [192.168.0.88] server88-new
12:50:05 [INFO] [ssh.go:50] [192.168.0.30] huohua-test
12:50:05 [INFO] [ssh.go:50] [192.168.0.65] server65
12:50:05 [INFO] [ssh.go:50] [192.168.0.31] k8s-master

## this will output nothing   
$ ./sealos exec --cmd "hostname -i"  --node huohua-test031

## only exec on exsit nodes.
./sealos exec --cmd "hostname -i"  --node huohua-test031 --node 192.168.0.65
12:51:28 [INFO] [ssh.go:57] [ssh][192.168.0.65] cd /tmp && hostname -i
12:51:29 [INFO] [ssh.go:50] [192.168.0.65] 192.168.0.65

## when nodes ip is format but is not in kubernetes, will appear ssh session error , timeout. 
$ ./sealos exec --cmd "hostname -i"  --node huohua-test031 --node 192.168.9.65
12:52:14 [INFO] [ssh.go:57] [ssh][192.168.9.65] cd /tmp && hostname -i
12:53:14 [EROR] [ssh.go:60] [ssh][192.168.9.65]Error create ssh session failed,dial tcp 192.168.9.65:22: i/o timeout

</pre></details>

<details><summary><code>8. support kubernetes label exp like kubernetes.io/arch!=amd64  </code> Output</summary><br><pre>
$ kubectl get nodes --show-labels
NAME           STATUS   ROLES    AGE   VERSION   LABELS
huohua-test    Ready    <none>   93d   v1.18.3   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/os=linux,kubernetes.io/arch=amd64,kubernetes.io/hostname=huohua-test,kubernetes.io/os=linux,name=huohua
k8s-master     Ready    master   93d   v1.18.3   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/os=linux,kubernetes.io/arch=amd64,kubernetes.io/hostname=k8s-master,kubernetes.io/os=linux,node-role.kubernetes.io/master=
server65       Ready    <none>   89d   v1.18.3   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/os=linux,kubernetes.io/arch=amd64,kubernetes.io/hostname=server65,kubernetes.io/os=linux
server88-new   Ready    <none>   89d   v1.18.3   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/os=linux,kubernetes.io/arch=amd64,kubernetes.io/hostname=server88-new,kubernetes.io/os=linux,name=front
$ ./sealos exec --cmd  "hostname -i"  --label name!=front 
09:17:21 [INFO] [ssh.go:57] [ssh][192.168.0.65] cd /tmp && hostname -i
09:17:21 [INFO] [ssh.go:57] [ssh][192.168.0.30] cd /tmp && hostname -i
09:17:21 [INFO] [ssh.go:57] [ssh][192.168.0.31] cd /tmp && hostname -i
09:17:21 [INFO] [ssh.go:50] [192.168.0.30] 192.168.0.30
09:17:21 [INFO] [ssh.go:50] [192.168.0.65] 192.168.0.65
09:17:21 [INFO] [ssh.go:50] [192.168.0.31] 192.168.0.31

</pre></details>
