### PR TITLE
fix sealos etcd health check for mutil master

### DIFF
--- a/cmd/etcd.go
+++ b/cmd/etcd.go
@@ -156,6 +156,6 @@ func EtcdRestoreCmdFunc(cmd *cobra.Command, args []string) {
 }
 
 func EtcdHealthCmdFunc(cmd *cobra.Command, args []string) {
-	e := install.GetEtcdBackFlags()
+	e := install.GetHealthFlag()
 	e.HealthCheck()
 }

--- a/install/etcd_save.go
+++ b/install/etcd_save.go
@@ -207,6 +207,27 @@ type epHealth struct {
 	Error  string `json:"error"`
 }
 
+func GetHealthFlag() *EtcdFlags {
+	e := &EtcdFlags{}
+	if !e.CertFileExist() {
+		logger.Error("ETCD CaCert or key file is not exist.")
+		os.Exit(1)
+	}
+	err := e.Load("")
+	if err != nil {
+		logger.Error(err)
+		e.ShowDefaultConfig()
+		os.Exit(0)
+	}
+	for _, h := range e.Masters {
+		ip := reFormatHostToIp(h)
+		enpoint := fmt.Sprintf("%s:2379", ip)
+		e.EtcdHosts = append(e.EtcdHosts, ip)
+		e.Endpoints = append(e.Endpoints, enpoint)
+	}
+	return e
+}
+
 func (e *EtcdFlags) HealthCheck() {
 	cfgs := []*clientv3.Config{}
 	for _, ep := range e.Endpoints {

--- a/install/join.go
+++ b/install/join.go
@@ -101,6 +101,7 @@ func (s *SealosInstaller) JoinMasters(masters []string) {
 
 			cmdHosts := fmt.Sprintf("echo %s >> /etc/hosts", getApiserverHost(IpFormat(s.Masters[0])))
 			_ = SSHConfig.CmdAsync(master, cmdHosts)
+			// cmdMult := fmt.Sprintf("%s --apiserver-advertise-address %s", cmd, IpFormat(master))
 			_ = SSHConfig.CmdAsync(master, cmd)
 			cmdHosts = fmt.Sprintf(`sed "s/%s/%s/g" -i /etc/hosts`, getApiserverHost(IpFormat(s.Masters[0])), getApiserverHost(IpFormat(master)))
 			_ = SSHConfig.CmdAsync(master, cmdHosts)


### PR DESCRIPTION
[SKIP CI]seaols: 一句话简短描述该PR内容
fix sealos etcd health check for mutil master.
```
[root@K8s-DEV-master ~]# ./sealos etcd health
19:10:48 [INFO] [etcd_save.go:259] health check for etcd: [{192.168.160.243:2379 true 6.002112ms }]
[root@K8s-DEV-master ~]# ./sealos etcd health
19:16:41 [INFO] [etcd_save.go:280] health check for etcd: [{192.168.160.243:2379 true 9.874935ms } {192.168.160.244:2379 true 11.982802ms }]
```