### PR TITLE
fix 1.19.1 kube-controller-manager and kube-scheduler use the LocalAP…

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -40,6 +40,31 @@ var contact = `
                   常见问题：sealyun.com/faq
 `
 
+var exampleInit = `
+	# init with password with three master one node
+	sealos init --passwd your-server-password  \
+	--master 192.168.0.2 --master 192.168.0.3 --master 192.168.0.4 \
+	--node 192.168.0.5 --user root \
+	--version v1.18.0 --pkg-url=/root/kube1.18.0.tar.gz 
+	
+	# init with pk-file , when your server have different password
+	sealos init --pk /root/.ssh/id_rsa \
+	--master 192.168.0.2 --node 192.168.0.5 --user root \
+	--version v1.18.0 --pkg-url=/root/kube1.18.0.tar.gz 
+
+	# when use multi network. set a can-reach with --interface 
+ 	sealos init --interface 192.168.0.254 \
+	--master 192.168.0.2 --master 192.168.0.3 --master 192.168.0.4 \
+	--node 192.168.0.5 --user root --passwd your-server-password \
+	--version v1.18.0 --pkg-url=/root/kube1.18.0.tar.gz 
+	
+	# when your interface is not "eth*|en*|em*" like.
+	sealos init --interface your-interface-name \
+	--master 192.168.0.2 --master 192.168.0.3 --master 192.168.0.4 \
+	--node 192.168.0.5 --user root --passwd your-server-password \
+	--version v1.18.0 --pkg-url=/root/kube1.18.0.tar.gz 
+`
+
 // initCmd represents the init command
 var initCmd = &cobra.Command{
 	Use:   "init",
@@ -47,6 +72,7 @@ var initCmd = &cobra.Command{
 	Long: `sealos init --master 192.168.0.2 --master 192.168.0.3 --master 192.168.0.4 \
 	--node 192.168.0.5 --user root --passwd your-server-password \
 	--version v1.18.0 --pkg-url=/root/kube1.18.0.tar.gz`,
+	Example: exampleInit,
 	Run: func(cmd *cobra.Command, args []string) {
 		c := &install.SealConfig{}
 		// 没有重大错误可以直接保存配置. 但是apiservercertsans为空. 但是不影响用户 clean
@@ -86,7 +112,7 @@ func init() {
 	initCmd.Flags().StringVar(&install.Repo, "repo", "k8s.gcr.io", "choose a container registry to pull control plane images from")
 	initCmd.Flags().StringVar(&install.PodCIDR, "podcidr", "100.64.0.0/10", "Specify range of IP addresses for the pod network")
 	initCmd.Flags().StringVar(&install.SvcCIDR, "svccidr", "10.96.0.0/12", "Use alternative range of IP address for service VIPs")
-	initCmd.Flags().StringVar(&install.Interface, "interface", "eth.*|en.*|em.*", "name of network interface")
+	initCmd.Flags().StringVar(&install.Interface, "interface", "eth.*|en.*|em.*", "name of network interface, when use calico IP_AUTODETECTION_METHOD, set your ipv4 with can-reach=192.168.0.1")
 
 	initCmd.Flags().BoolVar(&install.WithoutCNI, "without-cni", false, "If true we not install cni plugin")
 	initCmd.Flags().StringVar(&install.Network, "network", "calico", "cni plugin, calico..")

--- a/install/constants.go
+++ b/install/constants.go
@@ -16,10 +16,14 @@ const (
 	// etcd backup
 	ETCDSNAPSHOTDEFAULTNAME = "snapshot"
 	ETCDDEFAULTBACKUPDIR    = "/opt/sealos/ectd-backup"
-	ETCDDEFAULTRESTOREDIR	= "/opt/sealos/ectd-restore"
-	ETCDDATADIR				= "/var/lib/etcd"
+	ETCDDEFAULTRESTOREDIR   = "/opt/sealos/ectd-restore"
+	ETCDDATADIR             = "/var/lib/etcd"
 	EtcdCacart              = "/root/.sealos/pki/etcd/ca.crt"
 	EtcdCert                = "/root/.sealos/pki/etcd/healthcheck-client.crt"
 	EtcdKey                 = "/root/.sealos/pki/etcd/healthcheck-client.key"
 	TMPDIR                  = "/tmp"
+
+	// kube file
+	KUBECONTROLLERCONFIGFILE = "/etc/kubernetes/controller-manager.conf"
+	KUBESCHEDULERCONFIGFILE  = "/etc/kubernetes/scheduler.conf"
 )

--- a/install/etcd_save.go
+++ b/install/etcd_save.go
@@ -43,7 +43,6 @@ func GetEtcdBackFlags() *EtcdFlags {
 		os.Exit(0)
 	}
 	// get Etcd host
-	e.EtcdHosts = e.Masters
 	e.BackDir = EtcdBackDir
 	e.Name = SnapshotName
 	e.LongName = fmt.Sprintf("%s/%s", e.BackDir, e.Name)

--- a/install/utils.go
+++ b/install/utils.go
@@ -133,6 +133,19 @@ func VersionToInt(version string) int {
 	return 0
 }
 
+//VersionToIntAll v1.19.1 ==> 1191
+func VersionToIntAll(version string) int {
+	version = strings.Replace(version,"v","", -1)
+	arr := strings.Split(version,".")
+	if len(arr) >= 3 {
+		str := arr[0] + arr[1] + arr[2]
+		if i, err := strconv.Atoi(str) ;err == nil {
+			return i
+		}
+	}
+	return 0
+}
+
 //IpFormat is
 func IpFormat(host string) string {
 	ipAndPort := strings.Split(host, ":")

--- a/install/utils_test.go
+++ b/install/utils_test.go
@@ -144,3 +144,24 @@ func TestFileExist(t *testing.T) {
 		})
 	}
 }
+
+func TestVersionToIntAll(t *testing.T) {
+	type args struct {
+		version string
+	}
+	tests := []struct {
+		name string
+		args args
+		want int
+	}{
+		{"test01", args{"v1.19.1"}, 1191},
+		{"test01", args{"v1.15.1"}, 1151},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := VersionToIntAll(tt.args.version); got != tt.want {
+				t.Errorf("VersionToInt() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/net/calico.go
+++ b/net/calico.go
@@ -9,7 +9,7 @@ func (c Calico) Manifests(template string) string {
 		template = c.Template()
 	}
 	if c.metadata.Interface == "" {
-		c.metadata.Interface = defaultInterface
+		c.metadata.Interface = "interface=" + defaultInterface
 	}
 	if c.metadata.CIDR == "" {
 		c.metadata.CIDR = defaultCIDR
@@ -627,7 +627,7 @@ spec:
             - name: IP
               value: "autodetect"
             - name: IP_AUTODETECTION_METHOD
-              value: "interface={{ .Interface }}"
+              value: "{{ .Interface }}"
             # Enable IPIP
             - name: CALICO_IPV4POOL_IPIP
               value: "{{if not .IPIP }}Off{{else}}Always{{end}}"

--- a/net/net_test.go
+++ b/net/net_test.go
@@ -7,7 +7,15 @@ import (
 
 func TestNewNetwork(t *testing.T) {
 	netyaml := NewNetwork("calico", MetaData{
-		Interface: "en.*|eth.*",
+		Interface: "interface=en.*|eth.*",
+		CIDR:      "10.1.1.1/24",
+		IPIP:      true,
+		MTU:       "1440",
+	}).Manifests("")
+	fmt.Println(netyaml)
+
+	netyaml = NewNetwork("calico", MetaData{
+		Interface: "can-reach=192.168.160.1",
 		CIDR:      "10.1.1.1/24",
 		IPIP:      true,
 		MTU:       "1440",


### PR DESCRIPTION
fix 1.19.1 kube-controller-manager and kube-scheduler use the LocalAPIEndpoint instead of the ControlPlaneEndpoint.
#462 
[SKIP CI]seaols: 一句话简短描述该PR内容
