### PR TITLE
fix bugs in readPipe function

### DIFF
--- a/pkg/sshcmd/sshutil/ssh.go
+++ b/pkg/sshcmd/sshutil/ssh.go
@@ -2,9 +2,10 @@ package sshutil
 
 import (
 	"bufio"
-	"github.com/wonderivan/logger"
 	"io"
 	"strings"
+
+	"github.com/wonderivan/logger"
 )
 
 //Cmd is in host exec cmd
@@ -34,8 +35,8 @@ func (ss *SSH) Cmd(host string, cmd string) []byte {
 }
 
 func readPipe(host string, pipe io.Reader, isErr bool) {
+	r := bufio.NewReader(pipe)
 	for {
-		r := bufio.NewReader(pipe)
 		line, _, err := r.ReadLine()
 		if line == nil {
 			return
@@ -87,7 +88,7 @@ func (ss *SSH) CmdAsync(host string, cmd string) error {
 	}()
 	<-doneerr
 	<-doneout
-	return nil
+	return session.Wait()
 }
 
 //CmdToString is in host exec cmd and replace to spilt str


### PR DESCRIPTION
[SKIP CI]seaols: 一句话简短描述该PR内容

修复readPipe的两个bug：
1. 第一个bug是bufio.NewReader需要在for循环之前，否则只会输出一行日志
2. 第二个bug是函数返回值为session.Wait()，否则session.Start()不会返回执行命令的错误码，即命令即使出错也不会报错