### PR TITLE
add sealos init gen  subcommand to get default config

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -93,7 +93,8 @@ var initCmd = &cobra.Command{
 		fmt.Println(contact)
 	},
 	PreRun: func(cmd *cobra.Command, args []string) {
-		if install.ExitInitCase() {
+		// 使用了cfgFile 就不进行preRun了
+		if cfgFile == "" && install.ExitInitCase()  {
 			cmd.Help()
 			os.Exit(install.ErrorExitOSCase)
 		}
@@ -101,6 +102,7 @@ var initCmd = &cobra.Command{
 }
 
 func init() {
+	initCmd.AddCommand(NewInitGenerateCmd())
 	rootCmd.AddCommand(initCmd)
 
 	// Here you will define your flags and configuration settings.
@@ -137,4 +139,15 @@ func init() {
 	// 不像用户暴露
 	// initCmd.Flags().StringVar(&install.CertPath, "cert-path", "/root/.sealos/pki", "cert file path")
 	// initCmd.Flags().StringVar(&install.CertEtcdPath, "cert-etcd-path", "/root/.sealos/pki/etcd", "etcd cert file path")
+}
+
+func NewInitGenerateCmd() *cobra.Command  {
+	return &cobra.Command{
+		Use: "gen",
+		Short: "show default sealos init config",
+		Run: func(cmd *cobra.Command, args []string) {
+			c := &install.SealConfig{}
+			c.ShowDefaultConfig()
+		},
+	}
 }

--- a/install/config.go
+++ b/install/config.go
@@ -178,19 +178,20 @@ func (c *SealConfig) ShowDefaultConfig() {
 	c.Masters = []string{"192.168.0.2", "192.168.0.2", "192.168.0.2"}
 	c.Nodes = []string{"192.168.0.3", "192.168.0.4"}
 	c.User = "root"
-	c.Passwd = "123"
+	c.Passwd = "123456"
 	c.PrivateKey = "/root/.ssh/id_rsa"
 	c.ApiServerDomian = "apiserver.cluster.local"
 	c.VIP = "10.103.97.2"
-	c.PkgURL = "/root/kube1.14.2.tar.gz"
-	c.Version = "v1.14.2"
+	c.PkgURL = "/root/kube1.17.13.tar.gz"
+	c.Version = "v1.17.13"
 	c.Repo = "k8s.gcr.io"
 	c.PodCIDR = "100.64.0.0/10"
 	c.SvcCIDR = "10.96.0.0/12"
-	c.ApiServerDomian = "cluster.local"
 	c.ApiServerCertSANs = []string{"apiserver.cluster.local", "127.0.0.1"}
 	c.CertPath = "/root/.sealos/pki"
 	c.CertEtcdPath = "/root/.sealos/pki/etcd"
+	c.LvscareName = "fanux/lvscare"
+	c.LvscareTag ="latest"
 
 	y, err := yaml.Marshal(c)
 	if err != nil {


### PR DESCRIPTION
add sealos init gen  subcommand to get default config
fix init with --config 
Signed-off-by: oldthreefeng <louisehong4168@gmail.com>

[SKIP CI]seaols: 一句话简短描述该PR内容
