### PR TITLE
Support docker deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,6 @@ FROM alpine AS UPX
 COPY --from=builder /sealos /sealos
 RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.aliyun.com/g' /etc/apk/repositories && \
 	apk add --update upx && upx /sealos
-FROM scratch
+FROM alpine
 COPY --from=UPX /sealos /bin/sealos
 ENTRYPOINT ["/bin/sealos"]


### PR DESCRIPTION
alpine 作为 base 测试 ok 

保持alpine apk 源的干净
第三层使用干净 alpine 作为 base
最后的镜像大小为18MB，较原镜像多出的6MB
```bash
docker image ls|grep sealos
sealos                                develop             a4942be0834e        1 hours ago         18MB
```

