### PR TITLE
/root/.kube/config设置为600，否则默认其它组有r权限，导致helm工具执行有警告

### DIFF
--- a/install/init.go
+++ b/install/init.go
@@ -139,7 +139,7 @@ func (s *SealosInstaller) InstallMaster0() {
 	}
 	decodeOutput(output)
 
-	cmd = `mkdir -p /root/.kube && cp /etc/kubernetes/admin.conf /root/.kube/config`
+	cmd = `mkdir -p /root/.kube && cp /etc/kubernetes/admin.conf /root/.kube/config && chmod 600 /root/.kube/config`
 	output = SSHConfig.Cmd(s.Masters[0], cmd)
 
 	if WithoutCNI {

--- a/install/join.go
+++ b/install/join.go
@@ -123,7 +123,7 @@ func (s *SealosInstaller) JoinMasters(masters []string) {
 			_ = SSHConfig.CmdAsync(master, cmd)
 			cmdHosts = fmt.Sprintf(`sed "s/%s/%s/g" -i /etc/hosts`, getApiserverHost(IpFormat(s.Masters[0])), getApiserverHost(IpFormat(master)))
 			_ = SSHConfig.CmdAsync(master, cmdHosts)
-			copyk8sConf := `mkdir -p /root/.kube && cp -i /etc/kubernetes/admin.conf /root/.kube/config`
+			copyk8sConf := `mkdir -p /root/.kube && cp -i /etc/kubernetes/admin.conf /root/.kube/config && chmod 600 /root/.kube/config`
 			_ = SSHConfig.CmdAsync(master, copyk8sConf)
 			cleaninstall := `rm -rf /root/kube || :`
 			_ = SSHConfig.CmdAsync(master, cleaninstall)


### PR DESCRIPTION
[SKIP CI]seaols: 解决helm执行的警告，如下：
root@master1:~# helm list
WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /root/.kube/config
WARNING: Kubernetes configuration file is world-readable. This is insecure. Location: /root/.kube/config
NAME    NAMESPACE       REVISION        UPDATED STATUS  CHART   APP VERSION
