### PR TITLE
clean master use --master ; clean node use --node, if not ;exit

### DIFF
--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -15,49 +15,37 @@
 package cmd
 
 import (
-	"errors"
-	"fmt"
 	"os"
 
+	"github.com/fanux/sealos/install"
 	"github.com/spf13/cobra"
 	"github.com/wonderivan/logger"
-	"golang.org/x/crypto/ssh/terminal"
-
-	"github.com/fanux/sealos/install"
 )
+
+var exampleCleanCmd = `
+	# clean  master
+	sealos clean --master 192.168.0.2 \
+	--master 192.168.0.3
+  
+	# clean  node  use --force/-f will be not prompt 
+	sealos clean --node 192.168.0.4 \
+	--node 192.168.0.5 --force
+
+	# clean master and node
+	sealos clean --master 192.168.0.2-192.168.0.3 \
+ 	--node 192.168.0.4-192.168.0.5
+	
+	# clean your kubernets HA cluster and use --force/-f will be not prompt (danger)
+	sealos clean --all -f
+`
 
 // cleanCmd represents the clean command
 var cleanCmd = &cobra.Command{
-	Use:   "clean",
-	Short: "Simplest way to clean your kubernets HA cluster",
-	Long:  `sealos clean`,
-	Run: func(cmd *cobra.Command, args []string) {
-		deleteNodes := install.ParseIPs(install.NodeIPs)
-		deleteMasters := install.ParseIPs(install.MasterIPs)
-		c := &install.SealConfig{}
-		err := c.Load(cfgFile)
-		if err != nil {
-			// 判断错误是否为配置文件不存在
-			if errors.Is(err, os.ErrNotExist) {
-				_, err = fmt.Fprint(os.Stdout, "Please enter the password to connect to the node:\n")
-				if err != nil {
-					logger.Error("fmt.Fprint err", err)
-					os.Exit(-1)
-				}
-				passwordTmp, err := terminal.ReadPassword(int(os.Stdin.Fd()))
-				if err != nil {
-					logger.Error("read password err", err)
-					os.Exit(-1)
-				}
-				install.SSHConfig.Password = string(passwordTmp)
-			} else {
-				logger.Error(err)
-				os.Exit(-1)
-			}
-		}
-		install.BuildClean(deleteNodes, deleteMasters)
-		c.Dump(cfgFile)
-	},
+	Use:     "clean",
+	Short:   "Simplest way to clean your kubernets HA cluster",
+	Long:    `sealos clean`,
+	Example: exampleCleanCmd,
+	Run:     CleanCmdFunc,
 }
 
 func init() {
@@ -77,4 +65,60 @@ func init() {
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
 	// cleanCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}
+
+func CleanCmdFunc(cmd *cobra.Command, args []string) {
+	deleteNodes := install.ParseIPs(install.NodeIPs)
+	deleteMasters := install.ParseIPs(install.MasterIPs)
+	c := &install.SealConfig{}
+	err := c.Load(cfgFile)
+	if err != nil {
+		// comment: if cfgFile is not exist; do not use sealos clean something.
+		// its danger for sealos do clean nodes without `~/.sealos/config.yaml`
+		//// 判断错误是否为配置文件不存在
+		//if errors.Is(err, os.ErrNotExist) {
+		//	_, err = fmt.Fprint(os.Stdout, "Please enter the password to connect to the node:\n")
+		//	if err != nil {
+		//		logger.Error("fmt.Fprint err", err)
+		//		os.Exit(-1)
+		//	}
+		//	passwordTmp, err := terminal.ReadPassword(int(os.Stdin.Fd()))
+		//	if err != nil {
+		//		logger.Error("read password err", err)
+		//		os.Exit(-1)
+		//	}
+		//	install.SSHConfig.Password = string(passwordTmp)
+		//} else {
+		logger.Error(err)
+		os.Exit(-1)
+		//}
+	}
+
+	// 使用 sealos clean --node   不小心写了 masterip.
+	if ok, node := deleteNodeIsExistInNodes(deleteNodes, c.Masters); ok {
+		logger.Error(`clean master Use "sealos clean --master %s" to clean it, exit...`, node)
+		os.Exit(-1)
+	}
+	// 使用 sealos clean --master 不小心写了 nodeip.
+	if ok, node := deleteNodeIsExistInNodes(deleteMasters, c.Nodes); ok {
+		logger.Error(`clean nodes Use "sealos clean --node %s" to clean it, exit...`, node)
+		os.Exit(-1)
+	}
+
+	install.BuildClean(deleteNodes, deleteMasters)
+	c.Dump(cfgFile)
+
+}
+
+// IsExistNodes
+func deleteNodeIsExistInNodes(deleteNodes []string, nodes []string) (bool, string) {
+	for _, node := range nodes {
+		for _, deleteNode := range deleteNodes {
+			// 如果ips 相同. 则说明删除错了.
+			if node == deleteNode {
+				return true, node
+			}
+		}
+	}
+	return false, ""
 }


### PR DESCRIPTION
测试通过..
[SKIP CI]seaols: 一句话简短描述该PR内容

```
[root@k8s-dev ~]# kubectl get nodes -owide
NAME        STATUS   ROLES    AGE   VERSION   INTERNAL-IP      EXTERNAL-IP   OS-IMAGE                KERNEL-VERSION           CONTAINER-RUNTIME
k8s-dev     Ready    master   57m   v1.19.4   192.168.60.136   <none>        CentOS Linux 7 (Core)   3.10.0-1160.el7.x86_64   docker://19.3.12
k8s-node1   Ready    <none>   56m   v1.19.4   192.168.60.138   <none>        CentOS Linux 7 (Core)   3.10.0-1160.el7.x86_64   docker://19.3.12
[root@k8s-dev ~]# ./sealos  clean --node 192.168.60.136
00:43:50 [EROR] [clean.go:99] clean master Use "sealos clean --master 192.168.60.136:22" to clean it, exit...
[root@k8s-dev ~]# ./sealos  clean --master 192.168.60.138
00:43:56 [EROR] [clean.go:104] clean nodes Use "sealos clean --node 192.168.60.138:22" to clean it, exit...
[root@k8s-dev ~]# 
[root@k8s-dev ~]# 
[root@k8s-dev ~]# ./sealos  clean --node 192.168.60.138
clean command will clean nodes [192.168.60.138:22], continue clean (y/n)?y
00:44:03 [INFO] [ssh.go:13] [ssh][192.168.60.138:22] sealos route --host 192.168.60.138
00:44:04 [DEBG] [ssh.go:25] [ssh][192.168.60.138:22]command result is: ok

00:44:04 [DEBG] [ssh.go:58] [ssh][192.168.60.138:22] kubeadm reset -f  -v 0
....
[root@k8s-dev ~]# ./sealos  join--node 192.168.60.138
....

[root@k8s-dev ~]# ./sealos  clean --node 192.168.60.138 
clean command will clean nodes [192.168.60.138:22], continue clean (y/n)?n
00:47:18 [DEBG] [clean.go:45] clean nodes command is skip
00:47:18 [WARN] [clean.go:70] clean nodes and masters is empty,please check your args and config.yaml.
```