### PR TITLE
[need to test] staging for cgroupdriver , fix #582

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
 - Ubuntu 16.04, 18.04, 20.04,  x86_64/ arm64
 - Centos/RHEL 7.6+,  x86_64/ arm64
 - 其他支持 systemd 的系统环境.  x86_64/ arm64
+- Kylin arm64
 
 ## kubernetes 版本
 

--- a/README_en.md
+++ b/README_en.md
@@ -18,6 +18,7 @@ Build a production kubernetes HA cluster.
 - Ubuntu 16.04， 18.04， 20.04 ,  x86_64/ arm64
 - Centos/RHEL 7.6+,  x86_64/ arm64
 - 99% systemd manage linux system。 x86_64/ arm64
+- Kylin arm64
 
 ## kubernetes Versions
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -40,6 +40,7 @@
 - Ubuntu 16.04， 18.04， 20.04 ,  x86_64/ arm64
 - Centos/RHEL 7.6+,  x86_64/ arm64
 - 其他支持 systemd 的系统环境.  x86_64/ arm64
+- Kylin arm64
 
 ## kubernetes 版本
 

--- a/install/constants.go
+++ b/install/constants.go
@@ -27,6 +27,8 @@ const (
 	// CriSocket
 	DefaultDockerCRISocket     = "/var/run/dockershim.sock"
 	DefaultContainerdCRISocket = "/run/containerd/containerd.sock"
+	DefaultCgroupDriver        = "cgroupfs"
+	DefaultSystemdCgroupDriver = "systemd"
 )
 
 const InitTemplateTextV1beta1 = string(`apiVersion: kubeadm.k8s.io/v1beta1
@@ -91,7 +93,9 @@ kind: KubeProxyConfiguration
 mode: "ipvs"
 ipvs:
   excludeCIDRs:
-  - "{{.VIP}}/32"`)
+  - "{{.VIP}}/32"
+---
+` + kubeletConfigDefault)
 
 const JoinCPTemplateTextV1beta2 = string(`apiVersion: kubeadm.k8s.io/v1beta2
 caCertPath: /etc/kubernetes/pki/ca.crt
@@ -114,7 +118,9 @@ controlPlane:
     bindPort: 6443
 {{- end}}
 nodeRegistration:
-  criSocket: {{.CriSocket}}`)
+  criSocket: {{.CriSocket}}
+---
+` + kubeletConfigDefault)
 
 const InitTemplateTextV1bate2 = string(`apiVersion: kubeadm.k8s.io/v1beta2
 kind: InitConfiguration
@@ -180,4 +186,87 @@ kind: KubeProxyConfiguration
 mode: "ipvs"
 ipvs:
   excludeCIDRs:
-  - "{{.VIP}}/32"`)
+  - "{{.VIP}}/32"
+---
+` + kubeletConfigDefault)
+
+const (
+	ContainerdShell = `if grep "SystemdCgroup = true"  /etc/containerd/config.toml &> /dev/null; then  
+driver=systemd
+else
+driver=cgroupfs
+fi
+echo ${driver}`
+	DockerShell = `driver=$(docker info -f "{{.CgroupDriver}}")
+	echo "${driver}"`
+
+  kubeletConfigDefault = `apiVersion: kubelet.config.k8s.io/v1beta1
+kind: KubeletConfiguration
+authentication:
+  anonymous:
+    enabled: false
+  webhook:
+    cacheTTL: 2m0s
+    enabled: true
+  x509:
+    clientCAFile: /etc/kubernetes/pki/ca.crt
+authorization:
+  mode: Webhook
+  webhook:
+    cacheAuthorizedTTL: 5m0s
+    cacheUnauthorizedTTL: 30s
+cgroupDriver: {{ .CgroupDriver}}
+cgroupsPerQOS: true
+clusterDomain: cluster.local
+configMapAndSecretChangeDetectionStrategy: Watch
+containerLogMaxFiles: 5
+containerLogMaxSize: 10Mi
+contentType: application/vnd.kubernetes.protobuf
+cpuCFSQuota: true
+cpuCFSQuotaPeriod: 100ms
+cpuManagerPolicy: none
+cpuManagerReconcilePeriod: 10s
+enableControllerAttachDetach: true
+enableDebuggingHandlers: true
+enforceNodeAllocatable:
+- pods
+eventBurst: 10
+eventRecordQPS: 5
+evictionHard:
+  imagefs.available: 15%
+  memory.available: 100Mi
+  nodefs.available: 10%
+  nodefs.inodesFree: 5%
+evictionPressureTransitionPeriod: 5m0s
+failSwapOn: true
+fileCheckFrequency: 20s
+hairpinMode: promiscuous-bridge
+healthzBindAddress: 127.0.0.1
+healthzPort: 10248
+httpCheckFrequency: 20s
+imageGCHighThresholdPercent: 85
+imageGCLowThresholdPercent: 80
+imageMinimumGCAge: 2m0s
+iptablesDropBit: 15
+iptablesMasqueradeBit: 14
+kubeAPIBurst: 10
+kubeAPIQPS: 5
+makeIPTablesUtilChains: true
+maxOpenFiles: 1000000
+maxPods: 110
+nodeLeaseDurationSeconds: 40
+nodeStatusReportFrequency: 10s
+nodeStatusUpdateFrequency: 10s
+oomScoreAdj: -999
+podPidsLimit: -1
+port: 10250
+registryBurst: 10
+registryPullQPS: 5
+rotateCertificates: true
+runtimeRequestTimeout: 2m0s
+serializeImagePulls: true
+staticPodPath: /etc/kubernetes/manifests
+streamingConnectionIdleTimeout: 4h0m0s
+syncFrequency: 1m0s
+volumeStatsAggPeriod: 1m0s`
+)

--- a/install/generator.go
+++ b/install/generator.go
@@ -54,11 +54,11 @@ func Template() []byte {
 }
 
 // JoinTemplate is generate JoinCP nodes configuration by master ip.
-func JoinTemplate(ip string) []byte {
-	return JoinTemplateFromTemplateContent(joinKubeadmConfig(), ip)
+func JoinTemplate(ip string, cgroup string) []byte {
+	return JoinTemplateFromTemplateContent(joinKubeadmConfig(), ip, cgroup)
 }
 
-func JoinTemplateFromTemplateContent(templateContent, ip string) []byte {
+func JoinTemplateFromTemplateContent(templateContent, ip, cgroup string) []byte {
 	tmpl, err := template.New("text").Parse(templateContent)
 	defer func() {
 		if r := recover(); r != nil {
@@ -80,6 +80,7 @@ func JoinTemplateFromTemplateContent(templateContent, ip string) []byte {
 		CriSocket = DefaultDockerCRISocket
 	}
 	envMap["CriSocket"] = CriSocket
+	envMap["CgroupDriver"] = cgroup
 	var buffer bytes.Buffer
 	_ = tmpl.Execute(&buffer, envMap)
 	return buffer.Bytes()
@@ -111,6 +112,7 @@ func TemplateFromTemplateContent(templateContent string) []byte {
 	envMap["Repo"] = Repo
 	envMap["Master0"] = IpFormat(MasterIPs[0])
 	envMap["Network"] = Network
+	envMap["CgroupDriver"] = CgroupDriver
 	var buffer bytes.Buffer
 	_ = tmpl.Execute(&buffer, envMap)
 	return buffer.Bytes()

--- a/install/generator_test.go
+++ b/install/generator_test.go
@@ -141,12 +141,12 @@ func TestJoinTemplate(t *testing.T) {
 	TokenCaCertHash = "sha256:a68c79c87368ff794ae50c5fd6a8ce13fdb2778764f1080614ddfeaa0e2b9d14"
 
 	VIP = vip
-	config.Cmd("127.0.0.1", "echo \""+string(JoinTemplate(IpFormat(masters[0])))+"\" > ~/aa")
-	t.Log(string(JoinTemplate(IpFormat(masters[0]))))
+	config.Cmd("127.0.0.1", "echo \""+string(JoinTemplate(IpFormat(masters[0]), "systemd"))+"\" > ~/aa")
+	t.Log(string(JoinTemplate(IpFormat(masters[0]), "cgroupfs")))
 
 	Version = "v1.19.0"
-	config.Cmd("127.0.0.1", "echo \""+string(JoinTemplate(""))+"\" > ~/aa")
-	t.Log(string(JoinTemplate("")))
+	config.Cmd("127.0.0.1", "echo \""+string(JoinTemplate("", "systemd"))+"\" > ~/aa")
+	t.Log(string(JoinTemplate("", "cgroupfs")))
 }
 
 var tepJoin = `apiVersion: kubeadm.k8s.io/v1beta2

--- a/install/init.go
+++ b/install/init.go
@@ -56,9 +56,24 @@ func BuildInit() {
 	i.PrintFinish()
 }
 
+func (s *SealosInstaller) getCgroupDriverFromShell(h string) string {
+	var output string
+	if For120(Version) {
+		cmd := ContainerdShell
+		output = SSHConfig.CmdToString(h, cmd, " ")
+	} else {
+		cmd := DockerShell
+		output = SSHConfig.CmdToString(h, cmd, " ")
+	}
+	output = strings.TrimSpace(output)
+	logger.Info("cgroup driver is %s", output)
+	return output 
+}
+
 //KubeadmConfigInstall is
 func (s *SealosInstaller) KubeadmConfigInstall() {
 	var templateData string
+	CgroupDriver = s.getCgroupDriverFromShell(s.Masters[0])
 	if KubeadmFile == "" {
 		templateData = string(Template())
 	} else {

--- a/install/vars.go
+++ b/install/vars.go
@@ -30,6 +30,7 @@ var (
 
 	//criSocket
 	CriSocket string
+	CgroupDriver string
 
 	VIP     string
 	PkgUrl  string


### PR DESCRIPTION
Signed-off-by: oldthreefeng <louisehong4168@gmail.com>

[SKIP CI]seaols: 一句话简短描述该PR内容

本次 PR的主要内容： 
- 使用`kubeadm init/join` 前，判断当前主机cgroupdriver 并在kubeadm-config.yaml 写入cgroupdriver.  

PR的优势: 
- 可以兼容节点不同的cgroupdriver . 比如 有 1/2/3三台机器 ,  1的`cgroup Driver `为 systemd, 2/3 为 cgroupfs.    当然这个不推荐.
- 可以减少一些因为cgroup不一致, 导致的安装报错问题. 增加安装的丝滑.
- 使用阿里云的kubelet的config.yaml(目前使用默认配置)配置.  减少默认配置造成的一些不必要的问题.
## 测试用例

需要测试`sealos init / join `
- [x]  1master 节点 1 node节点， 一致/不一致测试。  centos / ubuntu
- [ ]  3master节点测试.  一致测试
- [ ]  3master节点测试.  cgroup driver 不一致测试.
- [ ]  1master 3node 测试, cgroup driver 一致测试.
- [ ]  1master 3node cgroup driver 不一致测试.
- [ ]  1master 3node cgroup driver 不一致测试. 并且使用自定义的` kubeadm-config.yaml`  进行init. 