### PR TITLE
[WIP]Sealos kubeadm 1.23 v1beta3

### DIFF
--- a/install/check.go
+++ b/install/check.go
@@ -21,8 +21,7 @@ func (s *SealosInstaller) CheckValid() {
 	// 所有node节点
 	//nodes := append(Nodes, ParseIPs(NodeIPs)...)
 	//hosts := append(masters, nodes...)
-	var hosts []string
-	hosts = append(s.Masters, s.Nodes...)
+	var hosts = append(s.Masters, s.Nodes...)
 	if len(s.Hosts) == 0 && len(hosts) == 0 {
 		s.Print("Fail")
 		logger.Error("hosts not allow empty")

--- a/install/clean.go
+++ b/install/clean.go
@@ -155,7 +155,7 @@ func (s *SealosClean) cleanMaster(master string) {
 func clean(host string) {
 	cmd := "kubeadm reset -f " + vlogToStr()
 	_ = SSHConfig.CmdAsync(host, cmd)
-	cmd = fmt.Sprintf(`sed -i '/kubectl/d;/sealos/d' /root/.bashrc`)
+	cmd = `sed -i '/kubectl/d;/sealos/d' /root/.bashrc`
 	_ = SSHConfig.CmdAsync(host, cmd)
 	cmd = "modprobe -r ipip  && lsmod"
 	_ = SSHConfig.CmdAsync(host, cmd)
@@ -171,13 +171,13 @@ func clean(host string) {
 	_ = SSHConfig.CmdAsync(host, cmd)
 	cmd = fmt.Sprintf("sed -i \"/%s/d\" /etc/hosts ", ApiServer)
 	_ = SSHConfig.CmdAsync(host, cmd)
-	cmd = fmt.Sprint("rm -rf ~/kube")
+	cmd = "rm -rf ~/kube"
 	_ = SSHConfig.CmdAsync(host, cmd)
 	//clean pki certs
-	cmd = fmt.Sprint("rm -rf /etc/kubernetes/pki")
+	cmd = "rm -rf /etc/kubernetes/pki"
 	_ = SSHConfig.CmdAsync(host, cmd)
 	//clean sealos in /usr/bin/ except exec sealos
-	cmd = fmt.Sprint("ps -ef |grep -v 'grep'|grep sealos >/dev/null || rm -rf /usr/bin/sealos")
+	cmd = "ps -ef |grep -v 'grep'|grep sealos >/dev/null || rm -rf /usr/bin/sealos"
 	_ = SSHConfig.CmdAsync(host, cmd)
 }
 

--- a/install/constants.go
+++ b/install/constants.go
@@ -30,23 +30,22 @@ const (
 	DefaultCgroupDriver        = "cgroupfs"
 	DefaultSystemdCgroupDriver = "systemd"
 
-  KubeadmV1beta1 = "kubeadm.k8s.io/v1beta1"
-  KubeadmV1beta2 = "kubeadm.k8s.io/v1beta2"
-  KubeadmV1beta3 = "kubeadm.k8s.io/v1beta3"
-  Bootstraptokenv1 = "bootstraptoken/v1"
+	KubeadmV1beta1   = "kubeadm.k8s.io/v1beta1"
+	KubeadmV1beta2   = "kubeadm.k8s.io/v1beta2"
+	KubeadmV1beta3   = "kubeadm.k8s.io/v1beta3"
+	Bootstraptokenv1 = "bootstraptoken/v1"
 )
 
-
 const (
-  InitTemplateText = string(InitConfigurationDefault + 
-    ClusterConfigurationDefault +
-    kubeproxyConfigDefault + 
-    kubeletConfigDefault)
-  JoinCPTemplateText = string(bootstrapTokenDefault + 
-      JoinConfigurationDefault +
-      kubeletConfigDefault)
+	InitTemplateText = string(InitConfigurationDefault +
+		ClusterConfigurationDefault +
+		kubeproxyConfigDefault +
+		kubeletConfigDefault)
+	JoinCPTemplateText = string(bootstrapTokenDefault +
+		JoinConfigurationDefault +
+		kubeletConfigDefault)
 
-  bootstrapTokenDefault = `{{- if .BootstrapApi -eq "bootstraptoken/v1" }}
+	bootstrapTokenDefault = `{{- if eq .BootstrapApi "bootstraptoken/v1" }}
 apiVersion: {{.BootstrapApi}}
   {{- else}}
 apiVersion: {{.KubeadmApi}}
@@ -64,7 +63,7 @@ discovery:
     - {{.TokenDiscoveryCAHash}}
   timeout: 5m0s
 `
-  InitConfigurationDefault = `apiVersion: {{.KubeadmApi}}
+	InitConfigurationDefault = `apiVersion: {{.KubeadmApi}}
 kind: InitConfiguration
 localAPIEndpoint:
   advertiseAddress: {{.Master0}}
@@ -73,7 +72,7 @@ nodeRegistration:
   criSocket: {{.CriSocket}}
 `
 
-  JoinConfigurationDefault = `
+	JoinConfigurationDefault = `
 kind: JoinConfiguration
 {{- if .Master }}
 controlPlane:
@@ -83,9 +82,9 @@ controlPlane:
 {{- end}}
 nodeRegistration:
   criSocket: {{.CriSocket}}
-` 
+`
 
-  ClusterConfigurationDefault = `---
+	ClusterConfigurationDefault = `---
 apiVersion: {{.KubeadmApi}}
 kind: ClusterConfiguration
 kubernetesVersion: {{.Version}}
@@ -137,7 +136,7 @@ scheduler:
     readOnly: true
     pathType: File
 `
-  kubeproxyConfigDefault = `
+	kubeproxyConfigDefault = `
 ---
 apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
@@ -146,7 +145,7 @@ ipvs:
   excludeCIDRs:
   - "{{.VIP}}/32"
 `
-  kubeletConfigDefault = `
+	kubeletConfigDefault = `
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
@@ -218,7 +217,7 @@ streamingConnectionIdleTimeout: 4h0m0s
 syncFrequency: 1m0s
 volumeStatsAggPeriod: 1m0s`
 
-  ContainerdShell = `if grep "SystemdCgroup = true"  /etc/containerd/config.toml &> /dev/null; then  
+	ContainerdShell = `if grep "SystemdCgroup = true"  /etc/containerd/config.toml &> /dev/null; then  
 driver=systemd
 else
 driver=cgroupfs

--- a/install/constants.go
+++ b/install/constants.go
@@ -33,6 +33,26 @@ const (
 	KubeadmV1beta1   = "kubeadm.k8s.io/v1beta1"
 	KubeadmV1beta2   = "kubeadm.k8s.io/v1beta2"
 	KubeadmV1beta3   = "kubeadm.k8s.io/v1beta3"
+/*
+A list of changes since v1beta1:
+
+`certificateKey" field is added to InitConfiguration and JoinConfiguration.
+"ignorePreflightErrors" field is added to the NodeRegistrationOptions.
+The JSON "omitempty" tag is used in a more places where appropriate.
+The JSON "omitempty" tag of the "taints" field (inside NodeRegistrationOptions) is removed. See the Kubernetes 1.15 changelog for further details.
+
+
+A list of changes since v1beta2:
+
+The deprecated ClusterConfiguration.useHyperKubeImage field has been removed. Kubeadm no longer supports the hyperkube image.
+The ClusterConfiguration.dns.type field has been removed since CoreDNS is the only supported DNS server type by kubeadm.
+Include "datapolicy" tags on the fields that hold secrets. This would result in the field values to be omitted when API structures are printed with klog.
+Add InitConfiguration.skipPhases, JoinConfiguration.skipPhases to allow skipping a list of phases during kubeadm init/join command execution.
+Add InitConfiguration.nodeRegistration.imagePullPolicy" andJoinConfiguration.nodeRegistration.imagePullPolicy` to allow specifying the images pull policy during kubeadm "init" and "join". The value must be one of "Always", "Never" or "IfNotPresent". "IfNotPresent" is the default, which has been the existing behavior prior to this addition.
+Add InitConfiguration.patches.directory, JoinConfiguration.patches.directory to allow the user to configure a directory from which to take patches for components deployed by kubeadm.
+Move the BootstrapToken&lowast; API and related utilities out of the "kubeadm" API group to a new group "bootstraptoken". The kubeadm API version v1beta3 no longer contains the BootstrapToken&lowast; structures.
+
+*/
 	Bootstraptokenv1 = "bootstraptoken/v1"
 )
 

--- a/install/etcd_save.go
+++ b/install/etcd_save.go
@@ -193,12 +193,11 @@ func GetEtcdClient(ep []string) (*clientv3.Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	cli, err := clientv3.New(clientv3.Config{
+	return clientv3.New(clientv3.Config{
 		Endpoints:   ep,
 		DialTimeout: 5 * time.Second,
 		TLS:         clientTLS,
 	})
-	return cli, nil
 }
 
 type epHealth struct {

--- a/install/generator.go
+++ b/install/generator.go
@@ -12,25 +12,26 @@ import (
 var ConfigType string
 
 func setKubeadmApi(version string) {
-       major ,_ := GetMajorMinorInt(version)
-       switch  {
-               // 
-       case major < 120: 
-               KubeadmApi = KubeadmV1beta1
-               CriSocket = DefaultDockerCRISocket
-       case major < 123 && major >= 120 :
-               KubeadmApi = KubeadmV1beta2
-               CriSocket = DefaultContainerdCRISocket
-       case major >= 123 :
-               KubeadmApi = KubeadmV1beta3
-               CriSocket = DefaultContainerdCRISocket
-       default:
-               KubeadmApi = KubeadmV1beta3
-               CriSocket = DefaultContainerdCRISocket
-			   BootstrapApi = Bootstraptokenv1
-       }
-       logger.Info("KubeadmApi: %s", KubeadmApi)
-       logger.Info("CriSocket: %s", CriSocket)
+	major, _ := GetMajorMinorInt(version)
+	switch {
+	//
+	case major < 120:
+		KubeadmApi = KubeadmV1beta1
+		CriSocket = DefaultDockerCRISocket
+	case major < 123 && major >= 120:
+		KubeadmApi = KubeadmV1beta2
+		CriSocket = DefaultContainerdCRISocket
+	case major >= 123:
+		KubeadmApi = KubeadmV1beta3
+		CriSocket = DefaultContainerdCRISocket
+		BootstrapApi = Bootstraptokenv1
+	default:
+		KubeadmApi = KubeadmV1beta3
+		CriSocket = DefaultContainerdCRISocket
+		BootstrapApi = Bootstraptokenv1
+	}
+	logger.Debug("KubeadmApi: %s", KubeadmApi)
+	logger.Debug("CriSocket: %s", CriSocket)
 }
 
 func Config() {
@@ -100,6 +101,7 @@ func JoinTemplateFromTemplateContent(templateContent, ip, cgroup string) []byte 
 }
 
 func TemplateFromTemplateContent(templateContent string) []byte {
+	setKubeadmApi(Version)
 	tmpl, err := template.New("text").Parse(templateContent)
 	defer func() {
 		if r := recover(); r != nil {
@@ -126,6 +128,8 @@ func TemplateFromTemplateContent(templateContent string) []byte {
 	envMap["Master0"] = IpFormat(MasterIPs[0])
 	envMap["Network"] = Network
 	envMap["CgroupDriver"] = CgroupDriver
+	envMap["KubeadmApi"] = KubeadmApi
+	envMap["CriSocket"] = CriSocket
 	var buffer bytes.Buffer
 	_ = tmpl.Execute(&buffer, envMap)
 	return buffer.Bytes()

--- a/install/generator_test.go
+++ b/install/generator_test.go
@@ -32,6 +32,7 @@ func TestNetCiliumTemplate(t *testing.T) {
 	ApiServer = "apiserver.cluster.local"
 	Version = "1.20.5"
 	Network = "cilium"
+	CgroupDriver = DefaultCgroupDriver
 	t.Log(string(Template()))
 	Network = "calico"
 	t.Log(string(Template()))
@@ -39,6 +40,7 @@ func TestNetCiliumTemplate(t *testing.T) {
 	Network = "cilium"
 	t.Log(string(Template()))
 	Network = "calico"
+	CgroupDriver = DefaultSystemdCgroupDriver
 	t.Log(string(Template()))
 }
 
@@ -148,19 +150,3 @@ func TestJoinTemplate(t *testing.T) {
 	config.Cmd("127.0.0.1", "echo \""+string(JoinTemplate("", "systemd"))+"\" > ~/aa")
 	t.Log(string(JoinTemplate("", "cgroupfs")))
 }
-
-var tepJoin = `apiVersion: kubeadm.k8s.io/v1beta2
-caCertPath: /etc/kubernetes/pki/ca.crt
-discovery:
-  bootstrapToken: 
-    apiServerEndpoint: {{.Master0}}:6443
-    token: {{.TokenDiscovery}}
-    caCertHashes: 
-    - {{.TokenDiscoveryCAHash}}
-  timeout: 5m0s
-kind: JoinConfiguration
-controlPlane:
-  localAPIEndpoint:
-    advertiseAddress: {{.Master}}
-    bindPort: 6443
-`

--- a/install/init.go
+++ b/install/init.go
@@ -193,7 +193,7 @@ func (s *SealosInstaller) InstallMaster0() {
 	decodeOutput(output)
 
 	cmd = `mkdir -p /root/.kube && cp /etc/kubernetes/admin.conf /root/.kube/config && chmod 600 /root/.kube/config`
-	output = SSHConfig.Cmd(s.Masters[0], cmd)
+	SSHConfig.Cmd(s.Masters[0], cmd)
 
 	if WithoutCNI {
 		logger.Info("--without-cni is true, so we not install calico or flannel, install it by yourself")
@@ -236,7 +236,7 @@ func (s *SealosInstaller) InstallMaster0() {
 	configYamlDir := filepath.Join(home, ".sealos", "cni.yaml")
 	ioutil.WriteFile(configYamlDir, []byte(netyaml), 0755)
 	SSHConfig.Copy(s.Masters[0], configYamlDir, "/tmp/cni.yaml")
-	output = SSHConfig.Cmd(s.Masters[0], "kubectl apply -f /tmp/cni.yaml")
+	SSHConfig.Cmd(s.Masters[0], "kubectl apply -f /tmp/cni.yaml")
 }
 
 //SendKubeConfigs

--- a/install/join.go
+++ b/install/join.go
@@ -92,8 +92,7 @@ func (s *SealosInstaller) sendJoinCPConfig(joinMaster []string) {
 		wg.Add(1)
 		go func(master string) {
 			defer wg.Done()
-			var cgroup string
-			cgroup = s.getCgroupDriverFromShell(master)
+			cgroup := s.getCgroupDriverFromShell(master)
 			templateData := string(JoinTemplate(IpFormat(master), cgroup))
 			cmd := fmt.Sprintf(`echo "%s" > /root/kubeadm-join-config.yaml`, templateData)
 			_ = SSHConfig.CmdAsync(master, cmd)
@@ -149,8 +148,7 @@ func (s *SealosInstaller) JoinNodes() {
 		go func(node string) {
 			defer wg.Done()
 			// send join node config
-			var cgroup string
-			cgroup = s.getCgroupDriverFromShell(node)
+			cgroup := s.getCgroupDriverFromShell(node)
 			templateData := string(JoinTemplate("", cgroup))
 			cmdJoinConfig := fmt.Sprintf(`echo "%s" > /root/kubeadm-join-config.yaml`, templateData)
 			_ = SSHConfig.CmdAsync(node, cmdJoinConfig)

--- a/install/upgrade.go
+++ b/install/upgrade.go
@@ -125,7 +125,7 @@ func (u *SealosUpgrade) upgradeNodes(hostnames []string, isMaster bool) {
 					os.Exit(1)
 				}
 			} else {
-				cmdUpgrade = fmt.Sprintf("kubeadm upgrade node --certificate-renewal=false")
+				cmdUpgrade = "kubeadm upgrade node --certificate-renewal=false"
 				err = SSHConfig.CmdAsync(ip, cmdUpgrade)
 				if err != nil {
 					logger.Error("kubeadm upgrade err: ", err)

--- a/install/utils.go
+++ b/install/utils.go
@@ -159,8 +159,7 @@ func IpFormat(host string) string {
 
 // RandString 生成随机字符串
 func RandString(len int) string {
-	var r *rand.Rand
-	r = rand.New(rand.NewSource(time.Now().Unix()))
+	var r *rand.Rand = rand.New(rand.NewSource(time.Now().Unix()))
 	bytes := make([]byte, len)
 	for i := 0; i < len; i++ {
 		b := r.Intn(26) + 65

--- a/install/vars.go
+++ b/install/vars.go
@@ -31,6 +31,8 @@ var (
 	//criSocket
 	CriSocket string
 	CgroupDriver string
+	KubeadmApi string
+	BootstrapApi string
 
 	VIP     string
 	PkgUrl  string

--- a/install/vars.go
+++ b/install/vars.go
@@ -29,9 +29,9 @@ var (
 	EtcdKey      = cert.SealosConfigDir + "/pki/etcd/healthcheck-client.key"
 
 	//criSocket
-	CriSocket string
+	CriSocket    string
 	CgroupDriver string
-	KubeadmApi string
+	KubeadmApi   string
 	BootstrapApi string
 
 	VIP     string


### PR DESCRIPTION
kubeadm 的 v1beta3 1.22 开始启动. 1.23 部分 api 开始切换, 因此 sealos 从 1.23 开始使用v1beta3.
需要测试一下: 

1.18.x/1.21.x/1.23.x

- [ ] 3 master 1 node ,  init/join 功能是否 ok. 
- [ ] 3 master 1 node ,  upgrade 功能是否 ok. 

此 pr 需要等 1.23.0 发布前一天合并.  v1beta3 功能完全 ok 即可合入. 

also fix #672 

and more kubeadm api `Implementation History` can be found in https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/kubeadm/970-kubeadm-config