### PR TITLE
replace Fatal to Alert. logger.fatal cause exit

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -53,7 +53,7 @@ var installCmd = &cobra.Command{
 		_ = appmanager.InstallApp(cfg, cfgFile)
 	},
 	PreRun: func(cmd *cobra.Command, args []string) {
-		logger.Fatal("the install app feature not support")
+		logger.Alert("the install app feature not support")
 		if install.ExitInstallCase(AppURL) {
 			_ = cmd.Help()
 			os.Exit(install.ErrorExitOSCase)


### PR DESCRIPTION
[SKIP CI]seaols: 一句话简短描述该PR内容

`logger.Fatal`内部会直接退出进程

```go
func (r *LocalLogger) Fatal(format string, args ...interface{}) {
	r.Emer("###Exec Panic:"+format, args...)
	os.Exit(1)
}
```